### PR TITLE
[#3][Feat] 채용담당자 기업 인증 개발

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -17,6 +17,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2023.0.2")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -39,12 +43,14 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-
-
-
-
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/backend/src/main/java/com/sabujaks/irs/IrsApplication.java
+++ b/backend/src/main/java/com/sabujaks/irs/IrsApplication.java
@@ -2,10 +2,12 @@ package com.sabujaks.irs;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients
 public class IrsApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/controller/AuthController.java
@@ -1,8 +1,12 @@
 package com.sabujaks.irs.domain.auth.controller;
 
+import com.sabujaks.irs.domain.auth.model.request.CompanyVerifyReq;
 import com.sabujaks.irs.domain.auth.model.request.RecruiterSignupReq;
 import com.sabujaks.irs.domain.auth.model.response.AuthSignupRes;
+import com.sabujaks.irs.domain.auth.model.response.CompanyVerifyRes;
+import com.sabujaks.irs.domain.auth.model.response.CrnApiRes;
 import com.sabujaks.irs.domain.auth.service.AuthService;
+import com.sabujaks.irs.domain.auth.service.CompanyVerifyService;
 import com.sabujaks.irs.domain.auth.service.EmailVerifyService;
 import com.sabujaks.irs.global.common.exception.BaseException;
 import com.sabujaks.irs.global.common.responses.BaseResponse;
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
     private final AuthService authService;
     private final EmailVerifyService emailVerifyService;
+    private final CompanyVerifyService crnVerifyService;
 
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<AuthSignupRes>> signup (
@@ -28,8 +33,8 @@ public class AuthController {
     }
 
     @GetMapping("/email-verify")
-    public ResponseEntity<BaseResponse> verify(
-            String email, String role, String uuid) throws Exception, BaseException {
+    public ResponseEntity<BaseResponse> emailVerify(
+        String email, String role, String uuid) throws Exception, BaseException {
         if(emailVerifyService.isExist(email, uuid)){
             authService.activeMember(email, role);
             return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.EMAIL_VERIFY_SUCCESS));
@@ -38,5 +43,10 @@ public class AuthController {
         }
     }
 
-
+    @PostMapping("/company-verify")
+    public ResponseEntity<BaseResponse<CrnApiRes>> companyVerify(
+        @RequestBody CompanyVerifyReq dto) throws BaseException {
+        CompanyVerifyRes response = crnVerifyService.companyVerify(dto);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.COMPANY_VERIFY_SUCCESS, response));
+    }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/entity/CompanyVerify.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/entity/CompanyVerify.java
@@ -1,0 +1,23 @@
+package com.sabujaks.irs.domain.auth.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompanyVerify {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+    private String crn; // 사업자 등록번호
+    private String ceoName; // 대표자명
+    private String openedAt; // 개업 일자
+    private String recruiterEmail; // 채용 담당자 이메일
+    private String companySecretCode; // 기업 전용 비밀 코드
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/entity/Recruiter.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/entity/Recruiter.java
@@ -26,7 +26,8 @@ public class Recruiter {
     private String password; // 비밀번호
     private String name; // 가입자명
     private String phoneNumber; // 사업자 등록 번호
-    private Boolean enabled; // 이메일 인증
+    private Boolean emailAuth; // 이메일 인증
+    private Boolean companyAuth; // 기업 인증
     private Boolean inactive; // 계정 비활성화 상태
     private String role; // 역할
 

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/request/CompanyVerifyReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/request/CompanyVerifyReq.java
@@ -1,0 +1,16 @@
+package com.sabujaks.irs.domain.auth.model.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CompanyVerifyReq {
+    private String crn;      // 사업자 번호
+    private String opened_at;  // 시작 날짜
+    private String ceo_name;      // 대표자 이름
+    private String recruiter_email; // 채용 담당자 이메일
+    private String company_secret_code; // 기업 비밀 코드
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/request/CrnApiReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/request/CrnApiReq.java
@@ -1,0 +1,27 @@
+package com.sabujaks.irs.domain.auth.model.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CrnApiReq {
+    private List<Business> businesses;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Business {
+        private String b_no;      // 사업자 번호 ("b_no"에 매핑)
+        private String start_dt;  // 시작 날짜 ("start_dt"에 매핑)
+        private String p_nm;      // 대표자 이름 ("p_nm"에 매핑)
+    }
+}
+

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/request/RecruiterSignupReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/request/RecruiterSignupReq.java
@@ -11,6 +11,6 @@ public class RecruiterSignupReq {
     private String email; // 이메일
     private String password; // 비밀번호
     private String name; // 가입자명
-    private String phoneNumber; // 휴대폰번호
+    private String phone_number; // 휴대폰번호
     private String role; // 역할
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/response/AuthSignupRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/response/AuthSignupRes.java
@@ -11,7 +11,6 @@ public class AuthSignupRes {
     private Long idx;
     private String email;
     private Boolean inactive;
-    private Boolean enabled;
+    private Boolean email_auth;
     private String role;
-
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/response/CompanyVerifyRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/response/CompanyVerifyRes.java
@@ -1,0 +1,13 @@
+package com.sabujaks.irs.domain.auth.model.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CompanyVerifyRes {
+    private String recruiter_email; // 채용 담당자 이메일
+    private Boolean auth_success; // 인증 성공 여부
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/response/CrnApiRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/response/CrnApiRes.java
@@ -1,0 +1,31 @@
+package com.sabujaks.irs.domain.auth.model.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CrnApiRes {
+
+    private int request_cnt;
+    private String status_code;
+    private List<DataInfo> data;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class DataInfo {
+        private String b_no;
+        private String valid;
+        private String valid_msg;
+    }
+}
+

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/repository/CompanyVerifyRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/repository/CompanyVerifyRepository.java
@@ -1,0 +1,13 @@
+package com.sabujaks.irs.domain.auth.repository;
+
+import com.sabujaks.irs.domain.auth.model.entity.CompanyVerify;
+import com.sabujaks.irs.domain.auth.model.entity.Recruiter;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface CompanyVerifyRepository  extends JpaRepository<CompanyVerify, Long> {
+    @Query("SELECT cv FROM CompanyVerify cv WHERE cv.recruiterEmail = :recruiterEmail")
+    Optional<CompanyVerify> findByRecruiterEmail(String recruiterEmail);
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/service/CompanyVerifyService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/service/CompanyVerifyService.java
@@ -1,0 +1,60 @@
+package com.sabujaks.irs.domain.auth.service;
+
+
+import com.sabujaks.irs.domain.auth.model.entity.CompanyVerify;
+import com.sabujaks.irs.domain.auth.model.request.CompanyVerifyReq;
+import com.sabujaks.irs.domain.auth.model.request.CrnApiReq;
+import com.sabujaks.irs.domain.auth.model.response.CompanyVerifyRes;
+import com.sabujaks.irs.domain.auth.model.response.CrnApiRes;
+import com.sabujaks.irs.domain.auth.repository.CompanyVerifyRepository;
+import com.sabujaks.irs.global.common.exception.BaseException;
+import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
+import com.sabujaks.irs.global.feign_client.CrnApiFeignClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class CompanyVerifyService {
+
+    @Value("${api-keys.company-registration-key}")
+    private String crnKey;
+
+    private final CrnApiFeignClient crnApiFeignClient;
+    private final CompanyVerifyRepository companyVerifyRepository;
+
+    // TODO: 어드민이 등록한 기준코드테이블에서 해당 기업의 시크릿 코드를 참조해 값을 가져와 비교하는 방식으로 반환
+    public CompanyVerifyRes companyVerify(CompanyVerifyReq dto) throws BaseException {
+        // 사업자 등록 번호 API 사용
+        CrnApiReq.Business business = CrnApiReq.Business.builder()
+                .b_no(dto.getCrn())
+                .start_dt(dto.getOpened_at())
+                .p_nm(dto.getCeo_name())
+                .build();
+        CrnApiReq crnApiReq = CrnApiReq.builder()
+                .businesses(List.of(business))
+                .build();
+        CrnApiRes crnApiRes = crnApiFeignClient.getCrnInfo(crnKey, crnApiReq);
+        System.out.println(crnApiRes.getData().get(0).getValid());
+        if (Objects.equals(crnApiRes.getData().get(0).getValid(), "02") || Objects.equals(crnApiRes.getData().get(0).getValid(), "01")){
+            CompanyVerify companyVerify = CompanyVerify.builder()
+                    .crn(dto.getCrn())
+                    .openedAt(dto.getOpened_at())
+                    .ceoName(dto.getCeo_name())
+                    .recruiterEmail(dto.getRecruiter_email())
+                    .companySecretCode(dto.getCompany_secret_code()) // 이부분은 admin이 관리해야함
+                    .build();
+            companyVerifyRepository.save(companyVerify);
+            return CompanyVerifyRes.builder()
+                    .recruiter_email(companyVerify.getRecruiterEmail())
+                    .auth_success(true)
+                    .build();
+        } else {
+            throw new BaseException(BaseResponseMessage.COMPANY_VERIFY_FAIL);
+        }
+    }
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/service/EmailVerifyService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/service/EmailVerifyService.java
@@ -44,7 +44,7 @@ public class EmailVerifyService {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(response.getEmail());
         if(Objects.equals(response.getRole(),"ROLE_RECRUITER")){
-            if(!response.getEnabled() && !response.getInactive()){
+            if(!response.getEmail_auth() && !response.getInactive()){
                 message.setSubject("IRS - 채용 담당자로 가입하신걸 환영합니다.");
             } else {
                 message.setSubject("IRS - 채용 담당자 계정 복구 이메일");

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -9,6 +9,7 @@ public enum BaseResponseMessage {
     MEMBER_REGISTER_SUCCESS(true, 1000, "회원가입에 성공했습니다. 이메일 인증 후 로그인 해주세요"),
     MEMBER_REGISTER_FAIL_MEMBER_ALREADY_EXITS(false, 1001, "이미 다른 계정이 존재합니다." ),
     MEMBER_REGISTER_FAIL_INVALID_ROLE(false, 1002, "유효하지 않은 회원가입입니다. "),
+    MEMBER_REGISTER_FAIL_NOT_COMPANY_AUTH(false, 1003, "기업 인증을 하지 않은 사용자는 가입할 수 없습니다."),
 
     // EMAIL_VERIFY 이메일 검증 1100
 
@@ -16,7 +17,13 @@ public enum BaseResponseMessage {
     EMAIL_VERIFY_FAIL(false, 1101, "이메일 검증을 실패했습니다."),
     EMAIL_VERIFY_FAIL_NOT_FOUND(false, 1102, "해당 유저를 찾을 수 없습니다."),
     EMAIL_VERIFY_FAIL_INVALID_ROLE(false, 1102, "유효하지 않은 이메일 검증입니다."),
-    EMAIL_SEND_FAIL(false, 1103, "이메일 전송에 실패했습니다.")
+    EMAIL_SEND_FAIL(false, 1103, "이메일 전송에 실패했습니다."),
+
+    // COMPANY_VERIFY 기업 인증 1200
+    COMPANY_VERIFY_SUCCESS(true, 1200, "기업 인증을 완료했습니다."),
+    COMPANY_VERIFY_FAIL(false, 1201, "기업 인증에 실패했습니다."),
+    COMPANY_VERIFY_FAIL_INVALID_REQUEST(false, 1202, "유효하지 않은 요청입니다.")
+
     ;
 
     private Boolean success;

--- a/backend/src/main/java/com/sabujaks/irs/global/feign_client/CrnApiFeignClient.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/feign_client/CrnApiFeignClient.java
@@ -1,0 +1,16 @@
+package com.sabujaks.irs.global.feign_client;
+
+import com.sabujaks.irs.domain.auth.model.request.CrnApiReq;
+import com.sabujaks.irs.domain.auth.model.response.CrnApiRes;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "crnApiFeignClient", url = "http://api.odcloud.kr/api/nts-businessman/v1")
+public interface CrnApiFeignClient {
+
+    @PostMapping("/validate")
+    CrnApiRes getCrnInfo(@RequestParam("serviceKey") String serviceKey, @RequestBody CrnApiReq crnApiReq);
+
+}

--- a/backend/src/main/java/com/sabujaks/irs/global/security/CustomUserDetailService.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/security/CustomUserDetailService.java
@@ -2,7 +2,6 @@ package com.sabujaks.irs.global.security;
 
 import com.sabujaks.irs.domain.auth.model.entity.Recruiter;
 import com.sabujaks.irs.domain.auth.repository.RecruiterRepository;
-import com.sabujaks.irs.global.security.filter.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -26,7 +25,7 @@ public class CustomUserDetailService implements UserDetailsService {
                     .email(recruiter.getEmail())
                     .password(recruiter.getPassword())
                     .role(recruiter.getRole())
-                    .enabled(recruiter.getEnabled())
+                    .emailAuth(recruiter.getEmailAuth())
                     .build();
         } else {
             return null;

--- a/backend/src/main/java/com/sabujaks/irs/global/security/CustomUserDetails.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/security/CustomUserDetails.java
@@ -1,4 +1,4 @@
-package com.sabujaks.irs.global.security.filter;
+package com.sabujaks.irs.global.security;
 
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
@@ -18,7 +18,7 @@ public class CustomUserDetails implements UserDetails {
     private final String name;
     private final String password;
     private final String role;
-    private final Boolean enabled;
+    private final Boolean emailAuth;
 
     public CustomUserDetails(Long idx, String email, String role) {
         this.idx = idx;
@@ -26,7 +26,7 @@ public class CustomUserDetails implements UserDetails {
         this.role = role;
         this.name = null;
         this.password = null;
-        this.enabled = null;
+        this.emailAuth = null;
     }
 
     @Override
@@ -69,6 +69,6 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return enabled;
+        return emailAuth;
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/global/security/filter/JwtFilter.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/security/filter/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.sabujaks.irs.global.security.filter;
 
+import com.sabujaks.irs.global.security.CustomUserDetails;
 import com.sabujaks.irs.global.utils.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/backend/src/main/java/com/sabujaks/irs/global/security/filter/LoginFilter.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/security/filter/LoginFilter.java
@@ -2,6 +2,7 @@ package com.sabujaks.irs.global.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sabujaks.irs.domain.auth.model.request.AuthLoginReq;
+import com.sabujaks.irs.global.security.CustomUserDetails;
 import com.sabujaks.irs.global.utils.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+api-keys:
+  company-registration-key: ${COMPANY_REGISTRATION_KEY}
 spring:
   jwt:
     secret: ${JWT_SECRET}


### PR DESCRIPTION
## 💭 연관된 이슈
closed: #3  
<br>

## 📌 구현 목표
채용담당자 기업 인증 기능 개발
<br>

## ✅ 주요구현 기능
채용담당자가 회원가입시 기업 인증요청을 보내면 기업인증 컨트롤러가 사업자 진위 여부 확인 API 호출
진위 여부 확인 후 API 요청파라미터와 채용담당자 이메일을 기업인증 테이블에 저장
채용담당자의 이메일이 기업인증 테이블에 존재한다면 채용 담당자의 회원가입 진행
<br>

