### PR TITLE
[Feat] 채용담당자 공고 등록 stpe2 지원서 폼 조립 기능

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/controller/AnnounceController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/controller/AnnounceController.java
@@ -1,0 +1,38 @@
+package com.sabujaks.irs.domain.announce.controller;
+
+import com.sabujaks.irs.domain.announce.model.entity.CustomForm;
+import com.sabujaks.irs.domain.announce.model.request.CustomFormReq;
+import com.sabujaks.irs.domain.announce.model.response.CustomFormRes;
+import com.sabujaks.irs.domain.announce.service.AnnounceService;
+import com.sabujaks.irs.domain.auth.model.request.AuthSignupReq;
+import com.sabujaks.irs.domain.resume.model.request.ResumeCreateReq;
+import com.sabujaks.irs.global.common.exception.BaseException;
+import com.sabujaks.irs.global.common.responses.BaseResponse;
+import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/recruiter/announce")
+@RequiredArgsConstructor
+public class AnnounceController {
+    private final AnnounceService announceService;
+
+    @RequestMapping(method = RequestMethod.POST, value = "/register-step2")
+    public ResponseEntity<BaseResponse<CustomFormReq>> registerStepTwo(
+            Long announceIdx,
+            @RequestPart("dto") CustomFormReq dto) throws BaseException {
+        //공고를 작성하고 step2로 넘어오면 -> 채용담당자(기본값), 공고idx가 넘어와야 함
+        //@AuthenticationPrincipal UserDetails userDetails 매개변수에 추가하기 (추후 수정 예정)
+//        if (customUserDetails == null) throw new BaseException(BaseResponseMessage.AUTH_FAIL);
+//        Long recruiterIdx = customUserDetails.getIdx();
+
+        //채용담당자도 넘길 필요가 있는지 고민
+        CustomFormRes response = announceService.registerCustomForm(announceIdx, dto);
+
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.ANNOUNCEMENT_REGISTER_STEP_TWO_SUCCESS, response));
+    }
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/model/entity/Announcement.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/model/entity/Announcement.java
@@ -1,0 +1,60 @@
+package com.sabujaks.irs.domain.announce.model.entity;
+
+import com.sabujaks.irs.domain.auth.model.entity.Recruiter;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Announcement { //공고
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    @Column(nullable = false, length = 50)
+    private String title; // 공고제목
+
+    @Column(nullable = false)
+    private LocalDateTime announcement_start; // 모집시작
+    @Column(nullable = false)
+    private LocalDateTime announcement_end; // 모집마감
+
+    @Column(nullable = false, length = 20)
+    private String job_category; // 직무 카테고리
+    @Column(nullable = false)
+    private String intro; // 회사소개
+    @Column(nullable = false)
+    private String position_qual; // 포지션&자격요건
+    @Column(nullable = false)
+    private String conditions; // 근무조건
+    @Column(nullable = false, length = 20)
+    private String region; // 근무지역
+    @Column(nullable = false)
+    private String benefits; // 복지&혜택
+    @Column(nullable = false)
+    private String process; // 전형절차
+
+    private String note; // 유의사항
+
+    @Column(length = 100)
+    private String img_url; // 공고 img
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruiter_idx")
+    private Recruiter recruiter; // 채용담당자 외래키
+
+    // 기업 외래키 필요
+
+    @OneToMany(mappedBy = "announcement" ,fetch = FetchType.LAZY)
+    private List<CustomForm> CustomFormList = new ArrayList<>(); // 지원서 맞춤양식 테이블과 관계
+    @OneToMany(mappedBy = "announcement" ,fetch = FetchType.LAZY)
+    private List<CustomLetterForm> CustomLetterFormList = new ArrayList<>(); // 자기소개서 맞춤양식 테이블과 관계
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/model/entity/CustomForm.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/model/entity/CustomForm.java
@@ -1,0 +1,24 @@
+package com.sabujaks.irs.domain.announce.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomForm { //지원서 맞춤 양식
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    @Column(nullable = false, length = 20)
+    private String code; // 맞춤 양식 코드
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "announcement_idx")
+    private Announcement announcement;
+
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/model/entity/CustomLetterForm.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/model/entity/CustomLetterForm.java
@@ -1,0 +1,26 @@
+package com.sabujaks.irs.domain.announce.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomLetterForm { //자기소개서 맞춤 양식
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    @Column(nullable = false, length = 100)
+    private String title; // 자기소개서 문항
+    @Column(nullable = false, length = 20)
+    private Integer chatLimit; // 글자수
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "announcement_idx")
+    private Announcement announcement;
+
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/model/request/CustomFormReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/model/request/CustomFormReq.java
@@ -1,0 +1,15 @@
+package com.sabujaks.irs.domain.announce.model.request;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomFormReq {
+    private List<String> code; // 맞춤 양식 코드 리스트
+    // 예시)"code": ["A001", "A002", "A003"]
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/model/response/CustomFormRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/model/response/CustomFormRes.java
@@ -1,0 +1,15 @@
+package com.sabujaks.irs.domain.announce.model.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomFormRes {
+    private List<String> code; // 맞춤 양식 코드 리스트
+//    private Long custom_form_idx; // 지원서 맞춤 양식 idx
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/repository/AnnounceRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/repository/AnnounceRepository.java
@@ -1,0 +1,12 @@
+package com.sabujaks.irs.domain.announce.repository;
+
+import com.sabujaks.irs.domain.announce.model.entity.Announcement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface AnnounceRepository extends JpaRepository<Announcement, Long> {
+    @Query("SELECT a FROM Announcement a WHERE a.idx = :announceIdx")
+    Optional<Announcement> findByAnnounceIdx(Long announceIdx);
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/repository/CustomFormRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/repository/CustomFormRepository.java
@@ -1,0 +1,7 @@
+package com.sabujaks.irs.domain.announce.repository;
+
+import com.sabujaks.irs.domain.announce.model.entity.CustomForm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomFormRepository extends JpaRepository<CustomForm, Long> {
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/repository/CustomLetterFormRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/repository/CustomLetterFormRepository.java
@@ -1,0 +1,7 @@
+package com.sabujaks.irs.domain.announce.repository;
+
+import com.sabujaks.irs.domain.announce.model.entity.CustomLetterForm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomLetterFormRepository extends JpaRepository<CustomLetterForm, Long> {
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/service/AnnounceService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/service/AnnounceService.java
@@ -1,0 +1,58 @@
+package com.sabujaks.irs.domain.announce.service;
+
+import com.sabujaks.irs.domain.announce.model.entity.Announcement;
+import com.sabujaks.irs.domain.announce.model.entity.CustomForm;
+import com.sabujaks.irs.domain.announce.model.request.CustomFormReq;
+import com.sabujaks.irs.domain.announce.model.response.CustomFormRes;
+import com.sabujaks.irs.domain.announce.repository.AnnounceRepository;
+import com.sabujaks.irs.domain.announce.repository.CustomFormRepository;
+import com.sabujaks.irs.domain.announce.repository.CustomLetterFormRepository;
+import com.sabujaks.irs.domain.auth.model.entity.Seeker;
+import com.sabujaks.irs.domain.resume.model.response.ResumeCreateRes;
+import com.sabujaks.irs.global.common.exception.BaseException;
+import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AnnounceService {
+    private final AnnounceRepository announceRepository;
+    private final CustomFormRepository customFormRepository;
+    private final CustomLetterFormRepository letterFormRepository;
+
+
+    /*******채용담당자 지원서 폼 조립 (step2)***********/
+    public CustomFormRes registerCustomForm(Long announceIdx, CustomFormReq dto) throws BaseException {
+        //클라이언트에서 넣을 폼을 선택한다 -> dto에 그 폼의 코드값이 들어온다
+
+        //예외 처리) 공고가 잘 저장되어 있는지 먼저 확인 필요
+        Optional<Announcement> result = announceRepository.findByAnnounceIdx(announceIdx);
+        if (result.isPresent()) {
+            //임시 배열
+            List<String> emsi = new ArrayList<>();
+
+            //리스트 길이만큼 커스텀 폼 엔티티 생성 후 저장
+            for(int i=0; i < dto.getCode().size(); i++) {
+                CustomForm customForm = CustomForm.builder()
+                        .code(dto.getCode().get(i))
+                        .announcement(result.get())
+                        .build();
+                customFormRepository.save(customForm);
+                emsi.add(dto.getCode().get(i));
+            }
+
+            //응답 (현재는 코드를 그대로 보이기 -> 추후 폼 이름 출력으로 수정 예정)
+            return CustomFormRes.builder()
+                    .code(emsi)
+                    .build();
+        } else {
+            throw new BaseException(BaseResponseMessage.ANNOUNCEMENT_REGISTER_STEP_TWO_FAIL_NOT_FOUND);
+        }
+
+    }
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/entity/Recruiter.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/entity/Recruiter.java
@@ -1,5 +1,7 @@
 package com.sabujaks.irs.domain.auth.model.entity;
 
+import com.sabujaks.irs.domain.announce.model.entity.Announcement;
+import com.sabujaks.irs.domain.announce.model.entity.CustomForm;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -7,6 +9,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 // 채용담당자 엔티티
 @Entity
@@ -35,5 +39,8 @@ public class Recruiter {
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "recruiter" ,fetch = FetchType.LAZY)
+    private List<Announcement> AnnouncementList = new ArrayList<>(); // 공고 테이블과 관계
 
 }

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -39,7 +39,12 @@ public enum BaseResponseMessage {
     // RESUME 2000~2999
     RESUME_REGISTER_SUCCESS(true, 2000, "지원서 등록에 성공했습니다."),
     RESUME_REGISTER_FAIL_NOT_FOUND(false, 2001, "해당 유저를 찾을 수 없습니다."),
-    RESUME_REGISTER_FAIL(false, 2002, "지원서 등록에 실패하였습니다." );
+    RESUME_REGISTER_FAIL(false, 2002, "지원서 등록에 실패하였습니다." ),
+
+    // ANNOUNCEMENT 3000~3999
+    ANNOUNCEMENT_REGISTER_STEP_TWO_SUCCESS(true, 2000, "지원서 폼 조립에 성공했습니다."),
+    ANNOUNCEMENT_REGISTER_STEP_TWO_FAIL_NOT_FOUND(false, 2001, "공고가 저장되지 않아 찾을 수 없습니다."),
+    ANNOUNCEMENT_REGISTER_STEP_TWO_FAIL(false, 2002, "지원서 폼 조립에 실패하였습니다." );
 
     private Boolean success;
     private Integer code;


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed: #32 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
도메인에 announce 폴더를 추가하여 공고 등록에 관련된 엔티티( 공고, 커스텀폼, 커스텀자기소개서폼)를 만들었음
지원서 폼 선택 시, base_info 테이블을 사용하기로 했으므로 각 폼의 코드가 리스트로 들어가도록 서비스를 개발함
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
<br>

## ✅ 주요구현 기능
<!-- 
- 좋아요 추가 및 제거
- 좋아요 개수 확인
-->
지원서 폼 조립 기능
<br>

<br>

