### PR TITLE
[#55][Feat] 채용담당자 화상 면접방 생성 개발

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -44,6 +44,10 @@ dependencies {
 	// Oauth2
 	implementation 'org.springframework.security:spring-security-oauth2-client'
 
+	// OpenVidu
+	implementation 'io.openvidu:openvidu-java-client:2.30.0'
+
+	// Lombok
 	compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.30'
 	annotationProcessor('org.projectlombok:lombok')
 

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/controller/InterviewScheduleController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/controller/InterviewScheduleController.java
@@ -23,7 +23,6 @@ public class InterviewScheduleController {
     public ResponseEntity<BaseResponse<InterviewScheduleReq>> create (
             @RequestBody InterviewScheduleReq dto) throws BaseException {
 
-
         for(String email : dto.getInterviewerList()) {
             System.out.println(email);
         }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/InterviewSchedule.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/InterviewSchedule.java
@@ -1,5 +1,6 @@
 package com.sabujaks.irs.domain.interview_schedule.model.entity;
 
+import com.sabujaks.irs.domain.video_interview.mdoel.entity.VideoInterviewRoom;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,4 +32,8 @@ public class InterviewSchedule {
 
     @Column(nullable = false)
     private String uuid;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="videoInterview_idx")
+    private VideoInterviewRoom videoInterviewRoom;
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/video_interview/controller/VideoInterviewController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/video_interview/controller/VideoInterviewController.java
@@ -1,0 +1,30 @@
+package com.sabujaks.irs.domain.video_interview.controller;
+
+import com.sabujaks.irs.domain.video_interview.mdoel.request.VideoInterviewRoomCreateReq;
+import com.sabujaks.irs.domain.video_interview.mdoel.response.VideoInterviewRoomCreateRes;
+import com.sabujaks.irs.domain.video_interview.service.VideoInterviewService;
+import com.sabujaks.irs.global.common.exception.BaseException;
+import com.sabujaks.irs.global.common.responses.BaseResponse;
+import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
+import io.openvidu.java.client.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@CrossOrigin(origins = "*")
+@RestController
+@RequestMapping("/api/video-interview")
+@RequiredArgsConstructor
+public class VideoInterviewController {
+    private final VideoInterviewService videoInterviewService;
+
+    @PostMapping("/room/create")
+    public ResponseEntity<BaseResponse<VideoInterviewRoomCreateRes>> createVideoInterviewRoom(
+        @RequestBody VideoInterviewRoomCreateReq dto) throws OpenViduJavaClientException, OpenViduHttpException, BaseException {
+        VideoInterviewRoomCreateRes response = videoInterviewService.createRoom(dto);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.VIDEO_INTERVIEW_ROOM_CREATE_SUCCESS, response));
+    }
+
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/video_interview/mdoel/entity/VideoInterviewRoom.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/video_interview/mdoel/entity/VideoInterviewRoom.java
@@ -1,0 +1,23 @@
+package com.sabujaks.irs.domain.video_interview.mdoel.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+// 화상 면접방 엔티티
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoInterviewRoom {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+    private String announceUUID;
+    private String videoInterviewRoomUUID;
+    // 위 엔티티의 UUID들은 다른테이블에서 연관관계로 매핑할 예정
+//    @OneToMany(mappedBy = "videoInterviewRoom")
+//    @JsonManagedReference
+//    private List<InterviewSchedule> interviewScheduleList = new ArrayList<>();
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/video_interview/mdoel/request/VideoInterviewRoomCreateReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/video_interview/mdoel/request/VideoInterviewRoomCreateReq.java
@@ -1,0 +1,16 @@
+package com.sabujaks.irs.domain.video_interview.mdoel.request;
+
+import lombok.*;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoInterviewRoomCreateReq {
+    private String announceUUID;
+    private Map<String, Object> params;
+    // params => {customSessionId: 세션 이름}
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/video_interview/mdoel/response/VideoInterviewRoomCreateRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/video_interview/mdoel/response/VideoInterviewRoomCreateRes.java
@@ -1,0 +1,12 @@
+package com.sabujaks.irs.domain.video_interview.mdoel.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoInterviewRoomCreateRes {
+    private Long idx;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/video_interview/repository/VideoInterviewRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/video_interview/repository/VideoInterviewRepository.java
@@ -1,0 +1,7 @@
+package com.sabujaks.irs.domain.video_interview.repository;
+
+import com.sabujaks.irs.domain.video_interview.mdoel.entity.VideoInterviewRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VideoInterviewRepository extends JpaRepository<VideoInterviewRoom, Long> {
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/video_interview/service/VideoInterviewService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/video_interview/service/VideoInterviewService.java
@@ -1,0 +1,32 @@
+package com.sabujaks.irs.domain.video_interview.service;
+
+import com.sabujaks.irs.domain.video_interview.mdoel.entity.VideoInterviewRoom;
+import com.sabujaks.irs.domain.video_interview.mdoel.request.VideoInterviewRoomCreateReq;
+import com.sabujaks.irs.domain.video_interview.mdoel.response.VideoInterviewRoomCreateRes;
+import com.sabujaks.irs.domain.video_interview.repository.VideoInterviewRepository;
+import com.sabujaks.irs.global.common.exception.BaseException;
+import io.openvidu.java.client.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VideoInterviewService {
+    private final OpenVidu openVidu;
+    private final VideoInterviewRepository videoInterviewRepository;
+    public VideoInterviewRoomCreateRes createRoom(VideoInterviewRoomCreateReq dto) throws OpenViduJavaClientException, OpenViduHttpException, BaseException {
+        SessionProperties properties = SessionProperties.fromJson(dto.getParams()).build();
+        Session session = openVidu.createSession(properties);
+        System.out.println("################################" + dto.getAnnounceUUID());
+        System.out.println("################################" + dto.getParams());
+        System.out.println(session.getSessionId());
+        VideoInterviewRoom videoInterviewRoom = VideoInterviewRoom.builder()
+                .announceUUID(dto.getAnnounceUUID())
+                .videoInterviewRoomUUID(session.getSessionId())
+                .build();
+        videoInterviewRepository.save(videoInterviewRoom);
+        return VideoInterviewRoomCreateRes.builder()
+                .idx(videoInterviewRoom.getIdx())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -37,7 +37,8 @@ public enum BaseResponseMessage {
 
     // INTERVIEW_SCHEDULE 면접 일정 1300
     INTERVIEW_SCHEDULE_CREATE_SUCCESS(true, 1300, "면접 일정 등록에 성공했습니다."),
-
+    // VIDEO_INTERVIEW 화상 면접 1400
+    VIDEO_INTERVIEW_ROOM_CREATE_SUCCESS(true, 1400, "화상 면접 방 생성에 성공했습니다."),
     // RESUME 2000~2999
     RESUME_REGISTER_SUCCESS(true, 2000, "지원서 등록에 성공했습니다."),
     RESUME_REGISTER_FAIL_NOT_FOUND(false, 2001, "해당 유저를 찾을 수 없습니다."),

--- a/backend/src/main/java/com/sabujaks/irs/global/config/OpenViduConfig.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/config/OpenViduConfig.java
@@ -1,0 +1,21 @@
+package com.sabujaks.irs.global.config;
+
+import io.openvidu.java.client.OpenVidu;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenViduConfig {
+
+    @Value("${OPENVIDU_URL}")
+    private String openviduUrl;
+
+    @Value("${OPENVIDU_SECRET}")
+    private String openviduSecret;
+
+    @Bean
+    public OpenVidu openvidu() {
+        return new OpenVidu(openviduUrl, openviduSecret);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -80,6 +80,9 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+openvidu:
+    url: ${OPENVIDU_URL}
+    secret: ${OPENVIDU_SECRET}
 logging:
   level:
     org.hibernate.SQL: debug

--- a/cicd/docker-compose.yml
+++ b/cicd/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - S3_ACCESS_KEY=${S3_ACCESS_KEY}
       - S3_BUCKET_NAME=${S3_BUCKET_NAME}
       - S3_SECRET_KEY=${S3_SECRET_KEY}
+      - OPENVIDU_URL=${OPENVIDU_URL}
+      - OPENVIDU_SECRET=${OPENVIDU_SECRET}
     volumes:
       - ../backend/build/libs:/backend
     command: "java -jar /backend/backend-0.0.1-SNAPSHOT.jar"

--- a/cicd/nginx/default.conf
+++ b/cicd/nginx/default.conf
@@ -9,7 +9,9 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
     }
+
     location /api {
         rewrite ^/api(.*)$ $1 break;
         proxy_pass         http://backend:8080/;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@fullcalendar/vue3": "^6.1.10",
         "axios": "^1.7.7",
         "core-js": "^3.8.3",
+        "openvidu-browser": "^2.30.1",
         "pinia": "^2.2.2",
         "pinia-plugin-persistedstate": "^4.0.0",
         "vue": "^3.2.13",
@@ -6746,7 +6747,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmmirror.com/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -7105,6 +7105,15 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/freeice": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/freeice/-/freeice-2.2.2.tgz",
+      "integrity": "sha512-XNoIxDHufqPIBSLpp4IrFPnoc+hv/0RwdOGhIoggIDC2ZKf5r6OoixbeoFJSmZOAq2aYiEUArhuQ8zVVrM5C4w==",
+      "license": "MIT",
+      "dependencies": {
+        "normalice": "^1.0.0"
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmmirror.com/fresh/-/fresh-0.5.2.tgz",
@@ -7373,6 +7382,15 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hark": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/hark/-/hark-1.2.3.tgz",
+      "integrity": "sha512-u68vz9SCa38ESiFJSDjqK8XbXqWzyot7Cj6Y2b6jk2NJ+II3MY2dIrLMg/kjtIAun4Y1DHF/20hfx4rq1G5GMg==",
+      "license": "MIT",
+      "dependencies": {
+        "wildemitter": "^1.2.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -7822,7 +7840,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -8156,6 +8173,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/jsnlog": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/jsnlog/-/jsnlog-2.30.0.tgz",
+      "integrity": "sha512-o3ROQVkhek+dkc7/9TXlB4TNtxUpYsRLOBJHZYk3Vy0B5zRBmfv9tyr56PrjcgEXuy06ARgfLTANY0+ImhzzGA==",
+      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -9157,6 +9180,12 @@
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "license": "MIT"
     },
+    "node_modules/normalice": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalice/-/normalice-1.0.1.tgz",
+      "integrity": "sha512-wF2/tv9q/K8S+RqCgll5yC6z/zcXNr+rEHfGIw8A6D58vjfJo+kp749MI6cAHv72LE7nwv92Qi6tZhIeMOOJpg==",
+      "license": "MIT"
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmmirror.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -9591,6 +9620,61 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/openvidu-browser": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/openvidu-browser/-/openvidu-browser-2.30.1.tgz",
+      "integrity": "sha512-R4OxEmr5syHisPxL8ndViqwYkUfe/muMPhwD1LhqnwObVDDZwI5LQTEVWSp2X8wc3GhWgNdQbsArpKqBUf3bzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "events": "3.3.0",
+        "freeice": "2.2.2",
+        "hark": "1.2.3",
+        "inherits": "2.0.4",
+        "jsnlog": "2.30.0",
+        "mime": "3.0.0",
+        "platform": "1.3.6",
+        "semver": "7.6.2",
+        "uuid": "9.0.1",
+        "wolfy87-eventemitter": "5.2.9"
+      }
+    },
+    "node_modules/openvidu-browser/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/openvidu-browser/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openvidu-browser/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/optionator": {
@@ -10045,6 +10129,12 @@
         "mlly": "^1.7.1",
         "pathe": "^1.1.2"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/portfinder": {
       "version": "1.0.32",
@@ -13401,6 +13491,17 @@
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/wildemitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/wildemitter/-/wildemitter-1.2.1.tgz",
+      "integrity": "sha512-UMmSUoIQSir+XbBpTxOTS53uJ8s/lVhADCkEbhfRjUGFDPme/XGOb0sBWLx5sTz7Wx/2+TlAw1eK9O5lw5PiEw=="
+    },
+    "node_modules/wolfy87-eventemitter": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.9.tgz",
+      "integrity": "sha512-P+6vtWyuDw+MB01X7UeF8TaHBvbCovf4HPEMF/SV7BdDc1SMTiBy13SRD71lQh4ExFTG1d/WNzDGDCyOKSMblw==",
+      "license": "Unlicense"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,17 +8,18 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "axios": "^1.7.7",
-    "core-js": "^3.8.3",
-    "pinia": "^2.2.2",
-    "pinia-plugin-persistedstate": "^4.0.0",
-    "vue": "^3.2.13",
-    "vue-router": "^4.4.3",
     "@fullcalendar/core": "^6.1.10",
     "@fullcalendar/daygrid": "^6.1.10",
     "@fullcalendar/interaction": "^6.1.10",
     "@fullcalendar/timegrid": "^6.1.10",
-    "@fullcalendar/vue3": "^6.1.10"
+    "@fullcalendar/vue3": "^6.1.10",
+    "axios": "^1.7.7",
+    "core-js": "^3.8.3",
+    "openvidu-browser": "^2.30.1",
+    "pinia": "^2.2.2",
+    "pinia-plugin-persistedstate": "^4.0.0",
+    "vue": "^3.2.13",
+    "vue-router": "^4.4.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/frontend/src/components/video-interview/OvVideo.vue
+++ b/frontend/src/components/video-interview/OvVideo.vue
@@ -1,0 +1,11 @@
+<template>
+	<video autoplay/>
+</template>
+
+<script>
+export default {
+	name: 'OvVideo',
+	props: { streamManager: Object, },
+	mounted () {this.streamManager.addVideoElement(this.$el);},
+};
+</script>

--- a/frontend/src/components/video-interview/UserVideo.vue
+++ b/frontend/src/components/video-interview/UserVideo.vue
@@ -1,0 +1,37 @@
+<template>
+    <div v-if="streamManager">
+        <ov-video :stream-manager="streamManager"/>
+        <div><p>{{ clientData }}</p></div>
+    </div>
+    </template>
+    
+    <script>
+    import OvVideo from './OvVideo';
+    
+    export default {
+        name: 'UserVideo',
+    
+        components: {
+            OvVideo,
+        },
+    
+        props: {
+            streamManager: Object,
+        },
+    
+        computed: {
+            clientData () {
+                const { clientData } = this.getConnectionData();
+                return clientData;
+            },
+        },
+    
+        methods: {
+            getConnectionData () {
+                const { connection } = this.streamManager.stream;
+                return JSON.parse(connection.data);
+            },
+        },
+    };
+    </script>
+    

--- a/frontend/src/const.js
+++ b/frontend/src/const.js
@@ -1,0 +1,1 @@
+export const backend = "/api/api";

--- a/frontend/src/pages/recruiter/video-interview/VideoInterViewTest1Page.vue
+++ b/frontend/src/pages/recruiter/video-interview/VideoInterViewTest1Page.vue
@@ -1,0 +1,192 @@
+<template>
+    <div id="main-container" class="container">
+      <div id="join" v-if="!session">
+        <div id="join-dialog" class="jumbotron vertical-center">
+          <h1>Join a video session</h1>
+          <div class="form-group">
+            <p>
+              <label>지원번호</label>
+              <input v-model="mySessionId" class="form-control" type="text" required />
+            </p>
+            <p>
+              <label>지원자 이름</label>
+              <input v-model="myUserName" class="form-control" type="text" required />
+            </p>
+            <p class="text-center">
+              <button class="btn btn-lg btn-success" @click="joinSession()">
+                Join!
+              </button>
+            </p>
+          </div>
+        </div>
+      </div>
+  
+      <div id="session" v-if="session">
+        <div id="session-header">
+          <h1 id="session-title">{{ mySessionId }}</h1>
+          <input class="btn btn-large btn-danger" type="button" id="buttonLeaveSession" @click="leaveSession"
+            value="Leave session" />
+        </div>
+        <div id="main-video" class="col-md-6">
+          <user-video :stream-manager="mainStreamManager" />
+        </div>
+        <div id="video-container" class="col-md-6">
+          <user-video :stream-manager="publisher" @click="updateMainVideoStreamManager(publisher)" />
+          <user-video v-for="sub in subscribers" :key="sub.stream.connection.connectionId" :stream-manager="sub"
+            @click="updateMainVideoStreamManager(sub)" />
+        </div>
+      </div>
+    </div>
+  </template>
+  
+  <script>
+import UserVideo from "@/components/video-interview/UserVideo.vue";
+import axios from "axios";
+  import { OpenVidu } from "openvidu-browser";
+  axios.defaults.headers.post["Content-Type"] = "application/json";
+  
+  export default {
+    name: "VideoInterViewPage",
+
+    components: { UserVideo, },
+  
+    data() {
+      return {
+        // OpenVidu 객체
+        OV: undefined,
+        session: undefined,
+        mainStreamManager: undefined,
+        publisher: undefined,
+        subscribers: [],
+  
+        // Join form
+        mySessionId: "SessionA",
+        myUserName: "Participant" + Math.floor(Math.random() * 100),
+      };
+    },
+  
+    methods: {
+      joinSession() {
+        // 1) Get an OpenVidu object ---
+        this.OV = new OpenVidu(); 
+        this.session = this.OV.initSession(); // 2) Init a session ---
+        // --- 3) Specify the actions when events take place in the session ---
+        // On every new Stream received...
+        this.session.on("streamCreated", ({ stream }) => {
+          const subscriber = this.session.subscribe(stream);
+          this.subscribers.push(subscriber);
+        });
+  
+        // On every Stream destroyed...
+        this.session.on("streamDestroyed", ({ stream }) => {
+          const index = this.subscribers.indexOf(stream.streamManager, 0);
+          if (index >= 0) {
+            this.subscribers.splice(index, 1);
+          }
+        });
+  
+        // On every asynchronous exception...
+        this.session.on("exception", ({ exception }) => { console.warn(exception); });
+  
+        // --- 4) Connect to the session with a valid user token ---
+  
+        // Get a token from the OpenVidu deployment
+        this.getToken(this.mySessionId).then((token) => {
+  
+          // First param is the token. Second param can be retrieved by every user on event
+          // 'streamCreated' (property Stream.connection.data), and will be appended to DOM as the user's nickname
+          this.session.connect(token, { clientData: this.myUserName })
+            .then(() => {
+  
+              // --- 5) Get your own camera stream with the desired properties ---
+  
+              // Init a publisher passing undefined as targetElement (we don't want OpenVidu to insert a video
+              // element: we will manage it on our own) and with the desired properties
+              let publisher = this.OV.initPublisher(undefined, {
+                audioSource: undefined, // The source of audio. If undefined default microphone
+                videoSource: undefined, // The source of video. If undefined default webcam
+                publishAudio: true, // Whether you want to start publishing with your audio unmuted or not
+                publishVideo: true, // Whether you want to start publishing with your video enabled or not
+                resolution: "640x480", // The resolution of your video
+                frameRate: 30, // The frame rate of your video
+                insertMode: "APPEND", // How the video is inserted in the target element 'video-container'
+                mirror: false, // Whether to mirror your local video or not
+              });
+  
+              // Set the main video in the page to display our webcam and store our Publisher
+              this.mainStreamManager = publisher;
+              this.publisher = publisher;
+  
+              // --- 6) Publish your stream ---
+  
+              this.session.publish(this.publisher);
+            })
+            .catch((error) => {
+              console.log("There was an error connecting to the session:", error.code, error.message);
+            });
+        });
+  
+        window.addEventListener("beforeunload", this.leaveSession);
+      },
+  
+      leaveSession() {
+        // --- 7) Leave the session by calling 'disconnect' method over the Session object ---
+        if (this.session) this.session.disconnect();
+  
+        // Empty all properties...
+        this.session = undefined;
+        this.mainStreamManager = undefined;
+        this.publisher = undefined;
+        this.subscribers = [];
+        this.OV = undefined;
+  
+        // Remove beforeunload listener
+        window.removeEventListener("beforeunload", this.leaveSession);
+      },
+  
+      updateMainVideoStreamManager(stream) {
+        if (this.mainStreamManager === stream) return;
+        this.mainStreamManager = stream;
+      },
+  
+      /**
+       * --------------------------------------------
+       * GETTING A TOKEN FROM YOUR APPLICATION SERVER
+       * --------------------------------------------
+       * The methods below request the creation of a Session and a Token to
+       * your application server. This keeps your OpenVidu deployment secure.
+       *
+       * In this sample code, there is no user control at all. Anybody could
+       * access your application server endpoints! In a real production
+       * environment, your application server must identify the user to allow
+       * access to the endpoints.
+       *
+       * Visit https://docs.openvidu.io/en/stable/application-server to learn
+       * more about the integration of OpenVidu in your application server.
+       */
+      async getToken(mySessionId) {
+        const sessionId = await this.createSession(mySessionId);
+        return await this.createToken(sessionId);
+      },
+  
+      async createSession(sessionId) {
+        const response = await axios.post(
+          '/api/api/video-interview/create', 
+          { customSessionId: sessionId 
+            
+          }, {
+          headers: { 'Content-Type': 'application/json', },
+        });
+        return response.data; // The sessionId
+      },
+  
+      async createToken(sessionId) {
+        const response = await axios.post('/api/api/video-interview/join/' + sessionId , {}, {
+          headers: { 'Content-Type': 'application/json', },
+        });
+        return response.data; // The token
+      },
+    },
+  };
+  </script>
+  

--- a/frontend/src/pages/recruiter/video-interview/VideoInterViewTest2Page.vue
+++ b/frontend/src/pages/recruiter/video-interview/VideoInterViewTest2Page.vue
@@ -1,0 +1,102 @@
+<template>
+  <div>
+    <h1>화상 면접방 생성 TEST</h1>
+    <p>면접 일정에서 화상 면접을 생성하고 일정을 생성하면 리스트 목록의 항목들에 면접방 생성 버튼이 나옴</p>
+    <p>=> 추후 이 부분은 일괄선택 처리(배치처리?)</p>
+    <p>면접방 생성 버튼을 누르면 해당 공고의 고유 UUID 와 면접일정 UUID가 전송됨 </p>
+    
+    <p>ex) 면접1팀(A,B,C) 09:00~10:00 지원자(D) / 10:00~11:00 지원자(E) / 11:00~12:00 지원자 (F) -> 면접일정 UUID는 같아야함</p>
+    <p>ex) 면접2팀(G,H,I) 09:00~10:00 지원자(J) / 10:00~11:00 지원자(K) / 11:00~12:00 지원자 (L) -> 면접일정 UUID는 같아야함</p>
+    <p>즉 면접팀이 같으면 면접일정의 UUID가 같아야하고 면접팀이 같아도 날짜가 다르면 UUID는 달라야한다.</p>
+    <p>면접방 항목은 공고제목(공고), 면접방 식별번호(면접일정) 면접 시작일(면접일정)</p>
+    <div class="ex-roomlist">
+      <p class="ex-roomitem">면접1팀 | 면접방 식별번호 | 면접 시작일 | [참여버튼]</p>
+      <p class="ex-roomitem">면접2팀 | 면접방 식별번호 | 면접 시작일 | [참여버튼]</p>
+    </div>
+  
+    <form @submit.prevent="submitForm">
+      <!-- UUID1 입력 -->
+      <label for="UUID1">UUID1은 공고를 구분한다. => 라우팅에 사용</label>
+      <p>ex) video-interview/room/UUID1 => 접속하면 공고별 면접 대기방이 나온다.</p>
+      <label for="uuid1">UUID1</label>
+      <p>ex) 3216d170-01a3-4202-8098-92e18d16a7a1</p>
+      <input type="text" v-model="uuid1" placeholder="Enter UUID1" />
+
+      <!-- UUID2 입력 -->
+      <p>ex) video-interview/room/UUID1/UUID2 => 다음은 면접방에 접속했을 때의 링크이다.</p>
+      <label for="uuid2">UUID2</label>
+      <input type="text" v-model="uuid2" placeholder="Enter UUID2" />
+
+      <!-- 제출 버튼 -->
+      <p>지원자에게 전송되는 이메일은 다음과 같다.</p>
+      <p>ex) http://localhost:8080/api/video-interview/room/{{ uuid1 }}/{{ uuid2 }} => Get 요청을 컨트롤러가 받음</p>
+      <button type="submit">Submit</button>
+      <p>dto 는 아래와 같다.</p>
+      <span>{</span>
+        <span>announceUUID: {{ uuid1.valueOf }}</span>
+        <span>params: { customSessionId: {{ uuid2.valueOf }}}</span>
+        <span>}</span>
+      <p>response는 다음과 같다.</p>
+      <span>{{ result.valueOf }}</span>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { UseVideoInterviewStore } from '@/stores/UseVideoInterviewStore'; // Pinia 스토어 import
+
+// UUID 값을 저장할 변수들
+const uuid1 = ref('');
+const uuid2 = ref('');
+const result = ref('');
+
+// Pinia store 사용
+const videoInterviewStore = UseVideoInterviewStore();
+// const getToken = async(uuid1) => {
+//         const sessionId = await this.createSession(uuid1);
+//         return await this.createToken(sessionId);
+// };
+
+// submitForm 함수
+const submitForm = async () => {
+  try {
+    console.log(uuid1)
+    console.log(uuid2)
+    const videoInterviewCreateRoomReq = {
+      announceUUID: uuid1.value,
+      params: { customSessionId: uuid2.value},
+    };
+    // Pinia 스토어의 createVideoInterviewRoom 액션 호출
+    const response = await videoInterviewStore.createVideoInterviewRoom(videoInterviewCreateRoomReq);
+    result.value = response
+    console.log('방 생성 성공:', response);
+  } catch (error) {
+    console.error('방 생성에 실패했습니다:', error);
+  }
+};
+</script>
+
+<style>
+  /* 간단한 스타일링 */
+  label {
+    display: block;
+    margin-top: 10px;
+  }
+  input {
+    margin-bottom: 10px;
+    display: block;
+  }
+  button {
+    margin-top: 10px;
+  }
+  .ex-roomlist{
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+  }
+  .ex-roomitem{
+    padding: 10px;
+    border: 1px solid black 
+  }
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -21,6 +21,8 @@ import MypageNotificationPage from '@/pages/seeker/mypage/MypageNotificationPage
 import SeekerSignupPage from '@/pages/seeker/auth/SeekerSignupPage.vue';
 import AnnounceRegisterStep2Page from '@/pages/recruiter/announce/AnnounceRegisterStep2Page.vue';
 import AnnounceRegisterStep1Page from "@/pages/recruiter/announce/AnnounceRegisterStep1Page.vue";
+import VideoInterViewTestPage from '@/pages/recruiter/video-interview/VideoInterViewTest1Page.vue';
+import VideoInterViewRoomCreatePage from '@/pages/recruiter/video-interview/VideoInterViewTest2Page.vue';
 
 
 const router = createRouter({
@@ -35,6 +37,8 @@ const router = createRouter({
         { path: '/recruiter/video-interview', component: VideoInterviewMainPage },
         { path: '/recruiter/video-interview/participant', component: VideoInterviewParticipantPage },
         { path: '/recruiter/video-interview/estimator', component: VideoInterviewEstimatorPage },
+        { path: '/recruiter/video-interview/test1', component: VideoInterViewTestPage},
+        { path: '/recruiter/video-interview/test2', component: VideoInterViewRoomCreatePage},
         { path: '/recruiter/interview-schedule', component: InterviewScheduleMainPage },
         { path: '/recruiter/resume', component: ResumeMainPage },
         { path: '/recruiter/resume/list', component: ResumeListPage },

--- a/frontend/src/stores/UseVideoInterviewStore.js
+++ b/frontend/src/stores/UseVideoInterviewStore.js
@@ -1,0 +1,23 @@
+import { defineStore } from 'pinia';
+import axios from 'axios';
+import { backend } from '@/const';
+
+
+export const UseVideoInterviewStore = defineStore('VideoInterview', {
+    state: () => ({
+        room: [],
+    }),
+    persist: { storage: sessionStorage, },
+    actions: {
+        async createVideoInterviewRoom(videoInterviewCreateRoomReq) {
+            try {
+                const response = await axios.post(`${backend}/video-interview/room/create`,
+                    videoInterviewCreateRoomReq ,
+                    { headers: { 'Content-Type': 'application/json', },});
+                return response.data
+            } catch (error) {
+                console.error("방 생성에 실패했습니다.")
+            }
+        },
+    },
+});


### PR DESCRIPTION
## 💭 연관된 이슈
closed: #55   
<br>

## 📌 구현 목표
채용담당자 화상 면접방 생성 기능 개발
<br>

## ✅ 주요구현 기능
1. OpenVidu를 사용해 화상 면접 기능을 구현, 기본적으로 제공하는 소켓 기능을 이용해 화상 면접방을 생성
2. 화상 면접방을 생성하고, 이와 관련된 추가 데이터를 VideoInterviewRoom테이블에 저장
3. VideoInterviewRoom Entity, DTO, Cotnroller, Service를 구현, 연관관계 매핑
4. 면접 일정을 생성하고 면접방을 생성할때 UUID를 생성해 SeesionId로 화상 면접방의 식별자로서 등록
5. 인증 방식이 없으면 누구나 면접방에 참여가 가능하므로 면접 시간대별 지원자 참여용 비밀번호를 생성
6. Vue에 테스트 페이지 생성

