### PR TITLE
[Feat] 채용담당자 자기소개서 등록 및 지원서 폼 코드 수정

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/controller/AnnounceController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/controller/AnnounceController.java
@@ -16,22 +16,21 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/recruiter/announce")
+@RequestMapping("/api/announce")
 @RequiredArgsConstructor
 public class AnnounceController {
     private final AnnounceService announceService;
 
     @RequestMapping(method = RequestMethod.POST, value = "/register-step2")
     public ResponseEntity<BaseResponse<CustomFormReq>> registerStepTwo(
-            Long announceIdx,
-            @RequestPart("dto") CustomFormReq dto) throws BaseException {
-        //공고를 작성하고 step2로 넘어오면 -> 채용담당자(기본값), 공고idx가 넘어와야 함
+            @RequestBody CustomFormReq dto) throws BaseException {
+        //공고를 작성하고 step2로 넘어오면 -> 채용담당자(기본값)?, 공고idx가 넘어와야 함
         //@AuthenticationPrincipal UserDetails userDetails 매개변수에 추가하기 (추후 수정 예정)
 //        if (customUserDetails == null) throw new BaseException(BaseResponseMessage.AUTH_FAIL);
 //        Long recruiterIdx = customUserDetails.getIdx();
 
         //채용담당자도 넘길 필요가 있는지 고민
-        CustomFormRes response = announceService.registerCustomForm(announceIdx, dto);
+        CustomFormRes response = announceService.registerCustomForm(dto);
 
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.ANNOUNCEMENT_REGISTER_STEP_TWO_SUCCESS, response));
     }

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/model/entity/Announcement.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/model/entity/Announcement.java
@@ -7,6 +7,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -29,19 +30,22 @@ public class Announcement { //공고
 
     @Column(nullable = false, length = 20)
     private String job_category; // 직무 카테고리
-    @Column(nullable = false)
+    @Column(columnDefinition = "TEXT")
     private String intro; // 회사소개
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String position_qual; // 포지션&자격요건
-    @Column(nullable = false)
+
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String conditions; // 근무조건
     @Column(nullable = false, length = 20)
     private String region; // 근무지역
-    @Column(nullable = false)
+
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String benefits; // 복지&혜택
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String process; // 전형절차
 
+    @Column(columnDefinition = "TEXT")
     private String note; // 유의사항
 
     @Column(length = 100)
@@ -51,10 +55,19 @@ public class Announcement { //공고
     @JoinColumn(name = "recruiter_idx")
     private Recruiter recruiter; // 채용담당자 외래키
 
-    // 기업 외래키 필요
+    // 기업 외래키 추가 필요
 
     @OneToMany(mappedBy = "announcement" ,fetch = FetchType.LAZY)
     private List<CustomForm> CustomFormList = new ArrayList<>(); // 지원서 맞춤양식 테이블과 관계
     @OneToMany(mappedBy = "announcement" ,fetch = FetchType.LAZY)
     private List<CustomLetterForm> CustomLetterFormList = new ArrayList<>(); // 자기소개서 맞춤양식 테이블과 관계
+
+    @Column(nullable = false, unique = true, updatable = false)
+    private String uuid; // UUID 필드 추가
+
+    // 공고 등록 시 uuid 생성, 공고등록step1이 없어서 테스트 못해봄! 11일에 할 예정, 아마 될거임
+    @PrePersist
+    public void createUUID() {
+        this.uuid = UUID.randomUUID().toString(); // UUID 자동 생성
+    }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/model/entity/CustomLetterForm.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/model/entity/CustomLetterForm.java
@@ -14,9 +14,9 @@ public class CustomLetterForm { //자기소개서 맞춤 양식
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false)
     private String title; // 자기소개서 문항
-    @Column(nullable = false, length = 20)
+
     private Integer chatLimit; // 글자수
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/model/request/CustomFormReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/model/request/CustomFormReq.java
@@ -10,6 +10,10 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class CustomFormReq {
+    private Long announceIdx;
     private List<String> code; // 맞춤 양식 코드 리스트
-    // 예시)"code": ["A001", "A002", "A003"]
+    // 예시)"code": ["resume_001", "resume_002", "resume_003"]
+
+    private List<String> titleList; // 자기소개서 문항 리스트
+    private List<Integer> chatLimitList; // 글자수 리스트
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/model/response/CustomFormRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/model/response/CustomFormRes.java
@@ -10,6 +10,8 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class CustomFormRes {
-    private List<String> code; // 맞춤 양식 코드 리스트
-//    private Long custom_form_idx; // 지원서 맞춤 양식 idx
+    private List<Long> baseInfoIdxList; // 기준코드표의 지원서 맞춤 양식 idx 리스트
+    private List<String> descriptionList; // 맞춤 양식 코드 설명 리스트
+
+    private List<Long> customFormLetterIdList; // 자기소개서 맞춤 양식 idx 리스트
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/service/AnnounceService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/service/AnnounceService.java
@@ -2,12 +2,15 @@ package com.sabujaks.irs.domain.announce.service;
 
 import com.sabujaks.irs.domain.announce.model.entity.Announcement;
 import com.sabujaks.irs.domain.announce.model.entity.CustomForm;
+import com.sabujaks.irs.domain.announce.model.entity.CustomLetterForm;
 import com.sabujaks.irs.domain.announce.model.request.CustomFormReq;
 import com.sabujaks.irs.domain.announce.model.response.CustomFormRes;
 import com.sabujaks.irs.domain.announce.repository.AnnounceRepository;
 import com.sabujaks.irs.domain.announce.repository.CustomFormRepository;
 import com.sabujaks.irs.domain.announce.repository.CustomLetterFormRepository;
 import com.sabujaks.irs.domain.auth.model.entity.Seeker;
+import com.sabujaks.irs.domain.data_init.entity.BaseInfo;
+import com.sabujaks.irs.domain.data_init.repository.BaseInfoRepository;
 import com.sabujaks.irs.domain.resume.model.response.ResumeCreateRes;
 import com.sabujaks.irs.global.common.exception.BaseException;
 import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
@@ -16,6 +19,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -24,31 +28,62 @@ public class AnnounceService {
     private final AnnounceRepository announceRepository;
     private final CustomFormRepository customFormRepository;
     private final CustomLetterFormRepository letterFormRepository;
+    private final BaseInfoRepository baseInfoRepository;
 
 
-    /*******채용담당자 지원서 폼 조립 (step2)***********/
-    public CustomFormRes registerCustomForm(Long announceIdx, CustomFormReq dto) throws BaseException {
+    /*******채용담당자 지원서 폼 조립 + 자기소개서 문항 등록 (step2)***********/
+    public CustomFormRes registerCustomForm(CustomFormReq dto) throws BaseException {
         //클라이언트에서 넣을 폼을 선택한다 -> dto에 그 폼의 코드값이 들어온다
 
         //예외 처리) 공고가 잘 저장되어 있는지 먼저 확인 필요
-        Optional<Announcement> result = announceRepository.findByAnnounceIdx(announceIdx);
-        if (result.isPresent()) {
-            //임시 배열
-            List<String> emsi = new ArrayList<>();
-
+        Optional<Announcement> resultAnnouncement = announceRepository.findByAnnounceIdx(dto.getAnnounceIdx());
+        if (resultAnnouncement.isPresent()) {
             //리스트 길이만큼 커스텀 폼 엔티티 생성 후 저장
             for(int i=0; i < dto.getCode().size(); i++) {
                 CustomForm customForm = CustomForm.builder()
                         .code(dto.getCode().get(i))
-                        .announcement(result.get())
+                        .announcement(resultAnnouncement.get())
                         .build();
                 customFormRepository.save(customForm);
-                emsi.add(dto.getCode().get(i));
             }
 
-            //응답 (현재는 코드를 그대로 보이기 -> 추후 폼 이름 출력으로 수정 예정)
+            String groupName = "custom_form";
+            List<BaseInfo> resultBaseInfoList = baseInfoRepository.findAllByGroupName(groupName);
+
+            //저장 배열
+            List<Long> emsiIdx = new ArrayList<>();
+            List<String> emsiDes = new ArrayList<>();
+
+            for(int i=0; i < resultBaseInfoList.size(); i++) {
+                for(int j=0; j < dto.getCode().size(); j++) {
+                    if(Objects.equals(resultBaseInfoList.get(i).getCode() , dto.getCode().get(j))) {
+                        emsiIdx.add(resultBaseInfoList.get(i).getIdx());
+                        emsiDes.add(resultBaseInfoList.get(i).getDescription());
+                    }
+                }
+            }
+
+            // 추가한 자기소개서 문항 등록
+
+            // 저장 배열
+            List<Long> emsiLetterIdx = new ArrayList<>();
+
+            //리스트 길이만큼 커스텀 레터 폼 엔티티 생성 후 저장
+            for(int i=0; i < dto.getTitleList().size(); i++) {
+                CustomLetterForm customLetterForm = CustomLetterForm.builder()
+                        .title(dto.getTitleList().get(i))
+                        .chatLimit(dto.getChatLimitList().get(i))
+                        .announcement(resultAnnouncement.get())
+                        .build();
+                letterFormRepository.save(customLetterForm);
+                emsiLetterIdx.add(customLetterForm.getIdx());
+            }
+
+            //응답
             return CustomFormRes.builder()
-                    .code(emsi)
+                    .baseInfoIdxList(emsiIdx)
+                    .descriptionList(emsiDes)
+                    .customFormLetterIdList(emsiLetterIdx)
                     .build();
         } else {
             throw new BaseException(BaseResponseMessage.ANNOUNCEMENT_REGISTER_STEP_TWO_FAIL_NOT_FOUND);

--- a/backend/src/main/java/com/sabujaks/irs/domain/data_init/repository/BaseInfoRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/data_init/repository/BaseInfoRepository.java
@@ -4,6 +4,10 @@ import com.sabujaks.irs.domain.data_init.entity.BaseInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface BaseInfoRepository extends JpaRepository<BaseInfo, Long> {
+    List<BaseInfo> findAllByGroupName(String groupName);
 }


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed: #112 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
공고 등록 과정 중 자기소개서 문항 추가에 대한 부분을 개발함
지원서 폼 조립 서비스에 자기소개서 dto까지 추가하여 한번에 저장되도록 수정함

<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
<br>

## ✅ 주요구현 기능
<!-- 
- 좋아요 추가 및 제거
- 좋아요 개수 확인
-->
채용담당자 공고 등록 중 step2 지원서 폼 등록과 자기소개서 문항 추가 등록
공고 entity에 공고 등록시 자동생성되는 uuid 추가 -> 공고등록 step1 기능은 아직 개발되지 않아 uuid 저장은 추후 확인 예정
<br>

<br>

