### PR TITLE
[#52][Feat] 면접 일정 설계 변경

### DIFF
--- a/frontend/src/components/recruiter/InterviewScheduleList.vue
+++ b/frontend/src/components/recruiter/InterviewScheduleList.vue
@@ -1,0 +1,75 @@
+<script setup>
+import { defineProps, defineEmits } from 'vue';
+
+// props를 정의합니다.
+const props = defineProps({
+  title: {
+    type: String,
+    required: true
+  }
+});
+
+const emit = defineEmits(['openModal', 'interviewScheduleMain']);
+
+const handleRowClick = (type) => {
+  emit('openModal', type);
+}
+
+</script>
+
+<template>
+  <div id="content">
+    <!-- props.title을 직접 사용합니다 -->
+    <h1>{{ props.title }}</h1>
+    <div class="col-12">
+      <div class="interview-add">
+        <button @click="handleRowClick('경력')">면접일정생성</button>
+      </div>
+    </div>
+    <table class="review-table">
+      <tr>
+        <th>번호</th>
+        <th>면접일정</th>
+        <th>??????</th>
+        <th>면접방생성</th>
+      </tr>
+      <tr>
+        <td>1</td>
+        <td>2024.09.24 - 2024.10.24</td>
+        <td>백엔드 엔지니어 신입공채</td>
+        <td><button>방 생성</button></td>
+      </tr>
+    </table>
+  </div>
+
+</template>
+
+<style scoped>
+.review-table th:nth-child(1) { /* 첫 번째 열 (번호) */
+  width: 10%; /* 비율 조정 */
+}
+
+.review-table th:nth-child(2) { /* 두 번째 열 (신입/경력) */
+  width: 40%; /* 비율 조정 */
+}
+
+.review-table th:nth-child(3) { /* 두 번째 열 (신입/경력) */
+  width: 30%; /* 비율 조정 */
+}
+
+.review-table th:nth-child(4) { /* 두 번째 열 (신입/경력) */
+  width: 20%; /* 비율 조정 */
+}
+
+.interview-add {
+  float: right;
+  margin: 10px 0;
+}
+
+.interview-add button {
+  background-color: #212b36;
+  color: white;
+  padding: 10px;
+  border-radius: 5px;
+}
+</style>

--- a/frontend/src/components/recruiter/InterviewScheduleMain.vue
+++ b/frontend/src/components/recruiter/InterviewScheduleMain.vue
@@ -1,0 +1,61 @@
+<script setup>
+import { defineProps, defineEmits, ref } from 'vue';
+
+// props를 정의합니다.
+const props = defineProps({
+  title: {
+    type: String,
+    required: true
+  }
+});
+
+const emit = defineEmits(['interviewScheduleList']);
+
+const announceIdx = ref(0);
+
+
+const handleRowClick = (announceIdx) => {
+  emit('interviewScheduleList', announceIdx);
+}
+</script>
+
+<template>
+  <div id="content">
+    <!-- props.title을 직접 사용합니다 -->
+    <h1>{{ props.title }}</h1>
+    <table class="review-table">
+      <tr>
+        <th>번호</th>
+        <th>공고기간</th>
+        <th>공고명</th>
+        <th>지원자수</th>
+      </tr>
+<!--      <tr @click="handleRowClick('경력')">-->
+      <tr @click="handleRowClick(announceIdx)">
+        <td>1</td>
+        <td>2024.09.24 - 2024.10.24</td>
+        <td>백엔드 엔지니어 신입공채</td>
+        <td>24</td>
+      </tr>
+    </table>
+  </div>
+
+</template>
+
+<style scoped>
+.review-table th:nth-child(1) { /* 첫 번째 열 (번호) */
+  width: 10%; /* 비율 조정 */
+}
+
+.review-table th:nth-child(2) { /* 두 번째 열 (신입/경력) */
+  width: 40%; /* 비율 조정 */
+}
+
+.review-table th:nth-child(3) { /* 두 번째 열 (신입/경력) */
+  width: 40%; /* 비율 조정 */
+}
+
+.review-table th:nth-child(4) { /* 두 번째 열 (신입/경력) */
+  width: 10%; /* 비율 조정 */
+}
+</style>

--- a/frontend/src/components/recruiter/MainSideBarComponent.vue
+++ b/frontend/src/components/recruiter/MainSideBarComponent.vue
@@ -1,14 +1,46 @@
-<script>
+<script setup>
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+
+// 면접 하위메뉴 토글 상태 관리
+const isInterviewMenuOpen = ref(true);
+
+// 메뉴 클릭 시 토글 함수
+const toggleInterviewMenu = () => {
+  isInterviewMenuOpen.value = !isInterviewMenuOpen.value;
+};
+
+const router = useRouter();
+
+const goAndReload = (path) => {
+  router.replace(path).then(() => {
+    window.location.reload();
+  });
+};
 
 </script>
 
 <template>
   <div class="sidebar">
     <ul>
-      <li>공고</li>
-      <li>지원서</li>
-      <li>면접</li>
-      <li>마이페이지</li>
+      <li> 공고</li>
+      <li> 지원서</li>
+      <!-- 면접 메뉴 클릭 시 하위메뉴 표시 및 화살표 아이콘 변경 -->
+      <li @click="toggleInterviewMenu" class="interview">
+        면접
+        <span class="icon">
+          ▼
+        </span>
+      </li>
+      <ul v-if="isInterviewMenuOpen" class="submenu">
+        <li @click="goAndReload('/recruiter/interview-schedule/new')">
+          신입
+        </li>
+        <li @click="goAndReload('/recruiter/interview-schedule/exp')">
+          경력
+        </li>
+      </ul>
+      <li> 마이페이지</li>
     </ul>
   </div>
 </template>
@@ -36,7 +68,6 @@
   color: #ffffff;
   text-decoration: none;
   margin: 10px 0;
-  font-size: 18px;
 }
 
 .sidebar ul {
@@ -46,12 +77,25 @@
 }
 
 .sidebar li {
-  padding: 15px 20px;
+  padding: 15px 40px;
   cursor: pointer;
 }
 
 .sidebar li:hover {
   background-color: #1a232d;
+}
+
+/* 하위 메뉴 스타일 */
+.submenu {
+  padding-left: 60px !important; /* 하위 메뉴 들여쓰기 */
+}
+
+.submenu li {
+  padding: 10px 0;
+}
+
+.icon {
+  font-size: 0.7rem;
 }
 
 </style>

--- a/frontend/src/pages/recruiter/interview-schedule/InterviewScheduleMainExp.vue
+++ b/frontend/src/pages/recruiter/interview-schedule/InterviewScheduleMainExp.vue
@@ -1,143 +1,16 @@
-<template>
-  <MainHeaderComponent />
-  <div class="container">
-    <MainSideBarComponent />
-    <div id="content">
-      <h1>면접 관리</h1>
-      <table class="review-table">
-        <tr>
-          <th>번호</th>
-          <th>신입/경력</th>
-        </tr>
-        <tr data-type="신입" @click="openModal('신입')">
-          <td>1</td>
-          <td>신입</td>
-        </tr>
-        <tr data-type="경력" @click="openModal('경력')">
-          <td>2</td>
-          <td>경력</td>
-        </tr>
-      </table>
-    </div>
-
-    <div v-if="isModalOpen" id="myModal" class="modal">
-      <div class="modal-content" id="draggableModal">
-        <span class="close" @click="closeModal">&times;</span>
-        <h2>{{ modalTitle }}</h2>
-        <div class="col-12 row mt-50 modal-section">
-          <div class="modal-left col-5 margin-auto">
-            <div class="form-group col-12 row">
-              <div class="col-11">
-                <label for="applicant">후보자 <span class="required">*</span></label>
-                <input type="text" id="applicant" placeholder="후보자를 추가해주세요." disabled>
-              </div>
-              <div class="col-1 add-button-section">
-                <button class="add-button" @click="addEmail">+</button>
-              </div>
-            </div>
-            <div id="selected-filters-list">
-              <span v-for="filter in selectedFilters" :key="filter" @click="removeFilter(filter)">
-                  {{ filter }} ✕
-              </span>
-            </div>
-            <div class="form-group col-12 row">
-              <div class="col-11">
-                <label for="participants">면접 참가자</label>
-                <input type="text" id="participants" placeholder="이메일을 입력해 주세요." v-model="participantEmail">
-              </div>
-              <div class="col-1 add-button-section">
-                <button class="add-email" @click="addParticipantEmail">+</button>
-              </div>
-            </div>
-            <div id="selected-emails-list">
-              <span v-for="email in selectedEmails" :key="email" @click="removeEmail(email)">
-                  {{ email }} ✕
-              </span>
-            </div>
-            <div class="form-group">
-              <div class="col-12">
-                <div class="form-group col-12 row">
-                  <div class="form-group col-5">
-                    <label for="interview-date" class="subtitle">날짜 <span class="required">*</span></label>
-                    <input type="date" id="interview-date" v-model="interviewDate">
-                  </div>
-                  <div class="form-group col-5 ml-auto">
-                    <label for="interview-type" class="subtitle">방식 <span class="required">*</span></label>
-                    <div class="row">
-                      <label class="checkbox-label">
-                        <input type="checkbox" name="choice" value="대면" v-model="interviewType"> 대면
-                      </label>
-
-                      <label class="checkbox-label ml-auto">
-                        <input type="checkbox" name="choice" value="온라인" v-model="interviewType"> 온라인
-                      </label>
-                    </div>
-                  </div>
-                </div>
-                <div class="form-group">
-                  <label for="start-time" class="subtitle">시작시간 <span class="required">*</span></label>
-                  <select class="time-select interview-calender" v-model="startTime">
-                    <option value="">시간을 선택하세요</option>
-                    <option v-for="time in timeOptions" :key="time" :value="time">{{ time }}</option>
-                  </select>
-                </div>
-                <div class="form-group">
-                  <label for="end-time" class="subtitle">종료시간 <span class="required">*</span></label>
-                  <select class="time-select interview-calender" v-model="endTime">
-                    <option value="">시간을 선택하세요</option>
-                    <option v-for="time in timeOptions" :key="time" :value="time">{{ time }}</option>
-                  </select>
-                </div>
-              </div>
-            </div>
-            <div class="col-12">
-              <button class="submit-button" @click="submitForm">등록</button>
-            </div>
-          </div>
-          <div class="modal-right col-5 margin-auto">
-            <div class='demo-app calendar' v-if="showCalendar">
-              <div class='demo-app-main'>
-                <FullCalendar
-                    class='demo-app-calendar'
-                    :options='calendarOptions'
-                >
-                  <template v-slot:eventContent='arg'>
-                    <b>{{ arg.timeText }}</b>
-                    <i>{{ arg.event.title }}</i>
-                  </template>
-                </FullCalendar>
-              </div>
-            </div>
-            <!-- 후보자 목록 -->
-            <div v-if="showInterviewerList" id="interviewer">
-              <div id="interviewers-list">
-                <h3>면접자 목록</h3>
-                <form id="nameForm">
-                  <label v-for="name in interviewers" :key="name">
-                    <input type="checkbox" :value="name" v-model="selectedInterviewers"> {{ name }}
-                  </label><br>
-                </form>
-              </div>
-              <div class="add-button-section">
-                <button class="submit-button" @click="selectInterviewers">선택</button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</template>
-
 <script setup>
 import { ref } from 'vue';
 import MainHeaderComponent from '../../../components/recruiter/MainHeaderComponent.vue';
 import MainSideBarComponent from '../../../components/recruiter/MainSideBarComponent.vue';
 import '@/assets/css/grid.css';
 import { UseInterviewScheduleStore } from '@/stores/UseInterviewScheduleStore';
+import InterviewScheduleMain from "../../../components/recruiter/InterviewScheduleMain.vue";
+import InterviewScheduleList from "@/components/recruiter/InterviewScheduleList.vue";
+
+const isInterviewScheduleMain = ref(true);
+const isInterviewScheduleList = ref(false);
 
 const interviewScheduleStore = UseInterviewScheduleStore(); // Store 인스턴스
-
 const isModalOpen = ref(false);
 const modalTitle = ref('');
 const participantEmail = ref('');
@@ -153,9 +26,16 @@ const showCalendar = ref(true); // 캘린더 기본으로 표시
 const showInterviewerList = ref(false); // 후보자 목록은 기본적으로 숨김
 const interviewType = ref([]); // 대면, 비대면 값 저장
 
-const openModal = (type) => {
-  modalTitle.value = type;
-  isModalOpen.value = true;
+const interviewScheduleLists = (announceIdx) => {
+  isInterviewScheduleList.value = true;
+  isInterviewScheduleMain.value = false;
+}
+// 모달 열기 함수에서 무한 호출 방지
+const openModal = (title) => {
+  if (!isModalOpen.value) {  // 모달이 열려있지 않을 때만 실행
+    modalTitle.value = title;
+    isModalOpen.value = true;
+  }
 };
 
 const closeModal = () => {
@@ -239,16 +119,137 @@ const submitForm = () => {
 
   // Store의 createInterviewSchedule 함수 호출
   interviewScheduleStore.createInterviewSchedule(interviewData)
-    .then(() => {
-      alert('면접 일정이 성공적으로 등록되었습니다.');
-    })
-    .catch((error) => {
-      console.error('면접 일정 등록 중 오류 발생:', error);
-    });
+      .then(() => {
+        alert('면접 일정이 성공적으로 등록되었습니다.');
+      })
+      .catch((error) => {
+        console.error('면접 일정 등록 중 오류 발생:', error);
+      });
 };
-
-
 </script>
+
+
+<template>
+  <MainHeaderComponent />
+  <div class="container">
+    <MainSideBarComponent />
+    <!-- InterviewScheduleMainNew에서 이벤트를 받아 모달을 제어 -->
+    <InterviewScheduleMain
+        v-if="isInterviewScheduleMain"
+        @interviewScheduleList="interviewScheduleLists"
+        :title="'경력'">
+    </InterviewScheduleMain>
+    <InterviewScheduleList
+        v-if="isInterviewScheduleList"
+        @openModal="openModal"
+        :title="'면접일정'">
+    </InterviewScheduleList>
+
+
+    <div v-if="isModalOpen" id="myModal" class="modal">
+      <div class="modal-content" id="draggableModal">
+        <span class="close" @click="closeModal">&times;</span>
+        <h2>{{ modalTitle }}</h2>
+        <div class="col-12 row mt-50 modal-section">
+          <div class="modal-left col-5 margin-auto">
+            <div class="form-group col-12 row">
+              <div class="col-11">
+                <label for="applicant">후보자 <span class="required">*</span></label>
+                <input type="text" id="applicant" placeholder="후보자를 추가해주세요." disabled>
+              </div>
+              <div class="col-1 add-button-section">
+                <button class="add-button" @click="addEmail">+</button>
+              </div>
+            </div>
+            <div id="selected-filters-list">
+              <span v-for="filter in selectedFilters" :key="filter" @click="removeFilter(filter)">
+                  {{ filter }} ✕
+              </span>
+            </div>
+            <div class="form-group col-12 row">
+              <div class="col-11">
+                <label for="participants">면접 참가자</label>
+                <input type="text" id="participants" placeholder="이메일을 입력해 주세요." v-model="participantEmail">
+              </div>
+              <div class="col-1 add-button-section">
+                <button class="add-email" @click="addParticipantEmail">+</button>
+              </div>
+            </div>
+            <div id="selected-emails-list">
+              <span v-for="email in selectedEmails" :key="email" @click="removeEmail(email)">
+                  {{ email }} ✕
+              </span>
+            </div>
+            <div class="form-group">
+              <div class="col-12">
+                <div class="form-group col-12 row">
+                  <div class="form-group col-5">
+                    <label for="interview-date" class="subtitle">날짜 <span class="required">*</span></label>
+                    <input type="date" id="interview-date" v-model="interviewDate">
+                  </div>
+                  <div class="form-group col-5 ml-auto">
+                    <label for="interview-type" class="subtitle">방식 <span class="required">*</span></label>
+                    <div class="row">
+                      <label class="checkbox-label">
+                        <input type="checkbox" name="choice" value="대면" v-model="interviewType"> 대면
+                      </label>
+
+                      <label class="checkbox-label ml-auto">
+                        <input type="checkbox" name="choice" value="온라인" v-model="interviewType"> 온라인
+                      </label>
+                    </div>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label for="start-time" class="subtitle">시작시간 <span class="required">*</span></label>
+                  <select class="time-select interview-calender" v-model="startTime">
+                    <option value="">시간을 선택하세요</option>
+                    <option v-for="time in timeOptions" :key="time" :value="time">{{ time }}</option>
+                  </select>
+                </div>
+                <div class="form-group">
+                  <label for="end-time" class="subtitle">종료시간 <span class="required">*</span></label>
+                  <select class="time-select interview-calender" v-model="endTime">
+                    <option value="">시간을 선택하세요</option>
+                    <option v-for="time in timeOptions" :key="time" :value="time">{{ time }}</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div class="col-12">
+              <button class="submit-button" @click="submitForm">등록</button>
+            </div>
+          </div>
+          <div class="modal-right col-5 margin-auto">
+            <div class='demo-app calendar' v-if="showCalendar">
+              <div class='demo-app-main'>
+                <FullCalendar
+                    class='demo-app-calendar'
+                    :options='calendarOptions'
+                >
+                </FullCalendar>
+              </div>
+            </div>
+            <!-- 후보자 목록 -->
+            <div v-if="showInterviewerList" id="interviewer">
+              <div id="interviewers-list">
+                <h3>면접자 목록</h3>
+                <form id="nameForm">
+                  <label v-for="name in interviewers" :key="name">
+                    <input type="checkbox" :value="name" v-model="selectedInterviewers"> {{ name }}
+                  </label><br>
+                </form>
+              </div>
+              <div class="add-button-section">
+                <button class="submit-button" @click="selectInterviewers">선택</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
 
 <script>
 import { defineComponent } from 'vue'
@@ -257,7 +258,6 @@ import dayGridPlugin from '@fullcalendar/daygrid'
 import timeGridPlugin from '@fullcalendar/timegrid'
 import interactionPlugin from '@fullcalendar/interaction'
 import { INITIAL_EVENTS, createEventId } from './event-utils'
-
 
 export default defineComponent({
   components: {
@@ -271,11 +271,16 @@ export default defineComponent({
           timeGridPlugin,
           interactionPlugin // needed for dateClick
         ],
+        locale: 'ko',
         headerToolbar: {
           left: 'prev,next today',
           center: 'title',
-          right: 'dayGridMonth,timeGridWeek,timeGridDay'
+          right: 'dayGridMonth,dayGridWeek,dayGridDay'
         },
+        events: [
+          { title: 'event 1', date: '2024-09-27' },
+          { title: 'event 2', date: '2024-09-30' }
+        ],
         initialView: 'dayGridMonth',
         initialEvents: INITIAL_EVENTS, // alternatively, use the `events` setting to fetch from a feed
         editable: true,
@@ -300,7 +305,7 @@ export default defineComponent({
       this.calendarOptions.weekends = !this.calendarOptions.weekends // update a property
     },
     handleDateSelect(selectInfo) {
-      let title = prompt('Please enter a new title for your event')
+      let title = prompt('새로운 일정을 등록해주세요.')
       let calendarApi = selectInfo.view.calendar
 
       calendarApi.unselect() // clear date selection
@@ -316,7 +321,7 @@ export default defineComponent({
       }
     },
     handleEventClick(clickInfo) {
-      if (confirm(`Are you sure you want to delete the event '${clickInfo.event.title}'`)) {
+      if (confirm(`일정을 삭제하시겠습니까? '${clickInfo.event.title}'`)) {
         clickInfo.event.remove()
       }
     },
@@ -330,13 +335,6 @@ export default defineComponent({
 
 
 <style scoped>
-.review-table th:nth-child(1) { /* 첫 번째 열 (번호) */
-  width: 20%; /* 비율 조정 */
-}
-
-.review-table th:nth-child(2) { /* 두 번째 열 (신입/경력) */
-  width: 80%; /* 비율 조정 */
-}
 
 .modal {
   display: flex;
@@ -493,19 +491,7 @@ input[type="text"] {
   font-size: 14px;
 }
 
-.demo-app-sidebar {
-  width: 300px;
-  line-height: 1.5;
-  background: #eaf9ff;
-  border-right: 1px solid #d3e2e8;
-}
-
-.demo-app-sidebar-section {
-  padding: 2em;
-}
-
 .demo-app-main {
   flex-grow: 1;
-  padding: 3em;
 }
 </style>

--- a/frontend/src/pages/recruiter/interview-schedule/InterviewScheduleMainNew.vue
+++ b/frontend/src/pages/recruiter/interview-schedule/InterviewScheduleMainNew.vue
@@ -1,0 +1,482 @@
+<template>
+  <MainHeaderComponent />
+  <div class="container">
+    <MainSideBarComponent />
+    <!-- InterviewScheduleMainNew에서 이벤트를 받아 모달을 제어 -->
+    <InterviewScheduleMain
+        @openModal="openModal" />
+
+    <div v-if="isModalOpen" id="myModal" class="modal">
+      <div class="modal-content" id="draggableModal">
+        <span class="close" @click="closeModal">&times;</span>
+        <h2>{{ modalTitle }}</h2>
+        <div class="col-12 row mt-50 modal-section">
+          <div class="modal-left col-5 margin-auto">
+            <div class="form-group col-12 row">
+              <div class="col-11">
+                <label for="applicant">후보자 <span class="required">*</span></label>
+                <input type="text" id="applicant" placeholder="후보자를 추가해주세요." disabled>
+              </div>
+              <div class="col-1 add-button-section">
+                <button class="add-button" @click="addEmail">+</button>
+              </div>
+            </div>
+            <div id="selected-filters-list">
+              <span v-for="filter in selectedFilters" :key="filter" @click="removeFilter(filter)">
+                  {{ filter }} ✕
+              </span>
+            </div>
+            <div class="form-group col-12 row">
+              <div class="col-11">
+                <label for="participants">면접 참가자</label>
+                <input type="text" id="participants" placeholder="이메일을 입력해 주세요." v-model="participantEmail">
+              </div>
+              <div class="col-1 add-button-section">
+                <button class="add-email" @click="addParticipantEmail">+</button>
+              </div>
+            </div>
+            <div id="selected-emails-list">
+              <span v-for="email in selectedEmails" :key="email" @click="removeEmail(email)">
+                  {{ email }} ✕
+              </span>
+            </div>
+            <div class="form-group">
+              <div class="col-12">
+                <div class="form-group col-12 row">
+                  <div class="form-group col-5">
+                    <label for="interview-date" class="subtitle">날짜 <span class="required">*</span></label>
+                    <input type="date" id="interview-date" v-model="interviewDate">
+                  </div>
+                  <div class="form-group col-5 ml-auto">
+                    <label for="interview-type" class="subtitle">방식 <span class="required">*</span></label>
+                    <div class="row">
+                      <label class="checkbox-label">
+                        <input type="checkbox" name="choice" value="대면" v-model="interviewType"> 대면
+                      </label>
+
+                      <label class="checkbox-label ml-auto">
+                        <input type="checkbox" name="choice" value="온라인" v-model="interviewType"> 온라인
+                      </label>
+                    </div>
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label for="start-time" class="subtitle">시작시간 <span class="required">*</span></label>
+                  <select class="time-select interview-calender" v-model="startTime">
+                    <option value="">시간을 선택하세요</option>
+                    <option v-for="time in timeOptions" :key="time" :value="time">{{ time }}</option>
+                  </select>
+                </div>
+                <div class="form-group">
+                  <label for="end-time" class="subtitle">종료시간 <span class="required">*</span></label>
+                  <select class="time-select interview-calender" v-model="endTime">
+                    <option value="">시간을 선택하세요</option>
+                    <option v-for="time in timeOptions" :key="time" :value="time">{{ time }}</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div class="col-12">
+              <button class="submit-button" @click="submitForm">등록</button>
+            </div>
+          </div>
+          <div class="modal-right col-5 margin-auto">
+            <div class='demo-app calendar' v-if="showCalendar">
+              <div class='demo-app-main'>
+                <FullCalendar
+                    class='demo-app-calendar'
+                    :options='calendarOptions'
+                >
+                </FullCalendar>
+              </div>
+            </div>
+            <!-- 후보자 목록 -->
+            <div v-if="showInterviewerList" id="interviewer">
+              <div id="interviewers-list">
+                <h3>면접자 목록</h3>
+                <form id="nameForm">
+                  <label v-for="name in interviewers" :key="name">
+                    <input type="checkbox" :value="name" v-model="selectedInterviewers"> {{ name }}
+                  </label><br>
+                </form>
+              </div>
+              <div class="add-button-section">
+                <button class="submit-button" @click="selectInterviewers">선택</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import MainHeaderComponent from '../../../components/recruiter/MainHeaderComponent.vue';
+import MainSideBarComponent from '../../../components/recruiter/MainSideBarComponent.vue';
+import '@/assets/css/grid.css';
+import { UseInterviewScheduleStore } from '@/stores/UseInterviewScheduleStore';
+import InterviewScheduleMain from "@/components/recruiter/InterviewScheduleMain.vue";
+
+const interviewScheduleStore = UseInterviewScheduleStore(); // Store 인스턴스
+
+const isModalOpen = ref(false);
+const modalTitle = ref('');
+const participantEmail = ref('');
+const selectedEmails = ref([]);
+const selectedFilters = ref([]);
+const interviewers = ref(['서시현', '구은주', '박종성', '서재은', '한별', '곽동현', '유송연', '강태성', '오규림', '송나경']);
+const selectedInterviewers = ref([]);
+const interviewDate = ref('');
+const startTime = ref('');
+const endTime = ref('');
+const timeOptions = ['09:00', '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00', '17:00', '18:00'];
+const showCalendar = ref(true); // 캘린더 기본으로 표시
+const showInterviewerList = ref(false); // 후보자 목록은 기본적으로 숨김
+const interviewType = ref([]); // 대면, 비대면 값 저장
+
+// 모달 열기 함수에서 무한 호출 방지
+const openModal = (title) => {
+  if (!isModalOpen.value) {  // 모달이 열려있지 않을 때만 실행
+    modalTitle.value = title;
+    isModalOpen.value = true;
+  }
+};
+
+const closeModal = () => {
+  isModalOpen.value = false;
+  resetModal();
+};
+
+const resetModal = () => {
+  participantEmail.value = '';
+  selectedEmails.value = [];
+  selectedFilters.value = [];
+  interviewDate.value = '';
+  startTime.value = '';
+  endTime.value = '';
+  selectedInterviewers.value = [];
+  showCalendar.value = true; // 모달을 닫을 때 캘린더가 다시 보이게 설정
+  showInterviewerList.value = false; // 모달을 닫을 때 후보자 목록은 숨김
+};
+
+const addParticipantEmail = () => {
+  const email = participantEmail.value.trim();
+  if (email && !selectedEmails.value.includes(email)) {
+    selectedEmails.value.push(email);
+    participantEmail.value = '';
+  }
+};
+
+const removeEmail = (email) => {
+  selectedEmails.value = selectedEmails.value.filter(item => item !== email);
+};
+
+const addEmail = () => {
+  // 캘린더를 숨기고 후보자 목록을 보여줌
+  showCalendar.value = !showCalendar.value;
+  if (showCalendar.value === false) {
+    showInterviewerList.value = true;
+  } else {
+    showInterviewerList.value = false;
+  }
+};
+
+const selectInterviewers = () => {
+  // 후보자 선택 후 캘린더를 다시 보여줌
+  selectedFilters.value = [...selectedInterviewers.value]; // 선택한 면접자 필터 업데이트
+  showInterviewerList.value = false;
+  showCalendar.value = true; // 캘린더 다시 표시
+};
+
+// 선택된 필터 삭제
+const removeFilter = (filter) => {
+  selectedFilters.value = selectedFilters.value.filter(item => item !== filter);
+  selectedInterviewers.value = selectedInterviewers.value.filter(item => item !== filter); // 체크박스 해제
+};
+
+const submitForm = () => {
+  const selectedSpanValues = selectedFilters.value;
+  const participantEmails = selectedEmails.value// 참가자 이메일
+  const selectedDate = interviewDate.value;
+  const selectedStartTime = startTime.value;
+  const selectedEndTime = endTime.value;
+  const selectedType = interviewType.value.join(', ');
+
+  alert(`
+    선택된 필터: ${selectedSpanValues}
+    면접관 이메일: ${participantEmails}
+    날짜: ${selectedDate}
+    방식: ${selectedType}
+    시작 시간: ${selectedStartTime}
+    종료 시간: ${selectedEndTime}
+  `);
+
+  // 데이터 객체 생성
+  const interviewData = {
+    seekerList: selectedSpanValues,
+    interviewerList: participantEmails,
+    isOnline: selectedType,
+    interviewDate: selectedDate,
+    interviewStart: selectedStartTime,
+    interviewEnd: selectedEndTime,
+  };
+
+  // Store의 createInterviewSchedule 함수 호출
+  interviewScheduleStore.createInterviewSchedule(interviewData)
+    .then(() => {
+      alert('면접 일정이 성공적으로 등록되었습니다.');
+    })
+    .catch((error) => {
+      console.error('면접 일정 등록 중 오류 발생:', error);
+    });
+};
+
+
+</script>
+
+<script>
+import { defineComponent } from 'vue'
+import FullCalendar from '@fullcalendar/vue3'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import interactionPlugin from '@fullcalendar/interaction'
+import { INITIAL_EVENTS, createEventId } from './event-utils'
+
+export default defineComponent({
+  components: {
+    FullCalendar,
+  },
+  data() {
+    return {
+      calendarOptions: {
+        plugins: [
+          dayGridPlugin,
+          timeGridPlugin,
+          interactionPlugin // needed for dateClick
+        ],
+        locale: 'ko',
+        headerToolbar: {
+          left: 'prev,next today',
+          center: 'title',
+          right: 'dayGridMonth,dayGridWeek,dayGridDay'
+        },
+        events: [
+          { title: 'event 1', date: '2024-09-27' },
+          { title: 'event 2', date: '2024-09-30' }
+        ],
+        initialView: 'dayGridMonth',
+        initialEvents: INITIAL_EVENTS, // alternatively, use the `events` setting to fetch from a feed
+        editable: true,
+        selectable: true,
+        selectMirror: true,
+        dayMaxEvents: true,
+        weekends: true,
+        select: this.handleDateSelect,
+        eventClick: this.handleEventClick,
+        eventsSet: this.handleEvents
+        /* you can update a remote database when these fire:
+        eventAdd:
+        eventChange:
+        eventRemove:
+        */
+      },
+      currentEvents: [],
+    }
+  },
+  methods: {
+    handleWeekendsToggle() {
+      this.calendarOptions.weekends = !this.calendarOptions.weekends // update a property
+    },
+    handleDateSelect(selectInfo) {
+      let title = prompt('새로운 일정을 등록해주세요.')
+      let calendarApi = selectInfo.view.calendar
+
+      calendarApi.unselect() // clear date selection
+
+      if (title) {
+        calendarApi.addEvent({
+          id: createEventId(),
+          title,
+          start: selectInfo.startStr,
+          end: selectInfo.endStr,
+          allDay: selectInfo.allDay
+        })
+      }
+    },
+    handleEventClick(clickInfo) {
+      if (confirm(`일정을 삭제하시겠습니까? '${clickInfo.event.title}'`)) {
+        clickInfo.event.remove()
+      }
+    },
+    handleEvents(events) {
+      this.currentEvents = events
+    },
+  }
+})
+
+</script>
+
+
+<style scoped>
+
+.modal {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 9;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 20px;
+  border-radius: 8px;
+  width: 80%;
+  height: 80%;
+}
+
+.modal-section {
+  height: 90%;
+}
+
+.close {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+}
+.close:hover,
+.close:focus {
+  color: black;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+h2 {
+  margin: 0 0 20px;
+}
+
+.form-group {
+  margin-bottom: 25px;
+}
+
+label {
+  display: block;
+  margin-bottom: 15px;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+label .subtitle {
+  font-weight: 400 !important;
+}
+
+input[type="text"] {
+  width: calc(100% - 40px);
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.add-button, .add-email {
+  padding: 10px;
+  background-color: #232b16;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.required {
+  color: red;
+}
+
+.calendar {
+  margin-top: 20px;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 5px;
+  margin-top: 10px;
+}
+
+.calendar-grid div {
+  padding: 10px;
+  text-align: center;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.submit-button {
+  width: 100%;
+  margin-top: 20px;
+  padding: 10px;
+  background-color: #232b16;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.add-button-section {
+  display: flex !important;
+  flex-direction: column;
+  justify-content: end;
+}
+
+#interview-date, .interview-calender {
+  width: 100%;
+  height: 30px;
+  text-align: center;
+  font-size: 1rem;
+}
+
+#interviewer {
+  overflow: auto;
+  height: 100%;
+}
+
+#interviewers-list {
+  max-height: 40%;
+  overflow-y: auto;
+  padding: 10px;
+  border: 1px solid #ccc;
+}
+
+#selected-filters-list, #selected-emails-list {
+  margin-bottom: 20px;
+}
+
+#selected-filters-list span, #selected-emails-list span {
+  background-color: #e0e0e0;
+  padding: 5px 10px;
+  margin-right: 10px;
+  margin-bottom: 10px;
+  border-radius: 20px;
+  display: inline-block;
+  font-size: 14px;
+  color: #333;
+  cursor: pointer;
+}
+
+
+.demo-app {
+  display: flex;
+  min-height: 100%;
+  font-family: Arial, Helvetica Neue, Helvetica, sans-serif;
+  font-size: 14px;
+}
+
+.demo-app-main {
+  flex-grow: 1;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,7 +2,6 @@
 import AnnounceDetailPage from '@/pages/seeker/announce/AnnounceDetailPage.vue';
 import AnnounceMainPage from '@/pages/recruiter/announce/AnnounceMainPage.vue';
 import RecruiterLoginPage from '@/pages/recruiter/auth/RecruiterLoginPage.vue';
-import InterviewScheduleMainPage from '@/pages/recruiter/interview-schedule/InterviewScheduleMainPage.vue';
 import ResumeMainPage from '@/pages/recruiter/resume/ResumeMainPage.vue';
 import VideoInterviewEstimatorPage from '@/pages/recruiter/video-interview/VideoInterviewEstimatorPage.vue';
 import VideoInterviewMainPage from '@/pages/recruiter/video-interview/VideoInterviewMainPage.vue';
@@ -21,7 +20,8 @@ import MypageNotificationPage from '@/pages/seeker/mypage/MypageNotificationPage
 import SeekerSignupPage from '@/pages/seeker/auth/SeekerSignupPage.vue';
 import AnnounceRegisterStep2Page from '@/pages/recruiter/announce/AnnounceRegisterStep2Page.vue';
 import AnnounceRegisterStep1Page from "@/pages/recruiter/announce/AnnounceRegisterStep1Page.vue";
-
+import InterviewScheduleMainNew from "@/pages/recruiter/interview-schedule/InterviewScheduleMainNew.vue";
+import InterviewScheduleMainExp from "@/pages/recruiter/interview-schedule/InterviewScheduleMainExp.vue";
 
 const router = createRouter({
     history: createWebHistory(),
@@ -35,7 +35,8 @@ const router = createRouter({
         { path: '/recruiter/video-interview', component: VideoInterviewMainPage },
         { path: '/recruiter/video-interview/participant', component: VideoInterviewParticipantPage },
         { path: '/recruiter/video-interview/estimator', component: VideoInterviewEstimatorPage },
-        { path: '/recruiter/interview-schedule', component: InterviewScheduleMainPage },
+        { path: '/recruiter/interview-schedule/new', component: InterviewScheduleMainNew },
+        { path: '/recruiter/interview-schedule/exp', component: InterviewScheduleMainExp },
         { path: '/recruiter/resume', component: ResumeMainPage },
         { path: '/recruiter/resume/list', component: ResumeListPage },
         { path: '/recruiter/resume/detail', component: ResumeDetailPage },


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #52 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
채용담당자는 신입과 경력의 면접 일정을 각각 조회할 수 있습니다.
면접일정생성 기능을 버튼을 따로 분리했습니다.
<br>

## ✅ 주요구현 기능
- 면접 초기 메인화면(공고리스트) 생성
- 각 공고 클릭시, 해당 공고에 해당하는 면접일정 리스트 페이지 생성
- 면접 일정 생성 버튼 생성

<br>

<br>

