### PR TITLE
[Fix] 공고등록 기능 코드 수정 및 쿼리문 개선

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/model/entity/Announcement.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/model/entity/Announcement.java
@@ -74,7 +74,7 @@ public class Announcement { //공고
     @Column(nullable = false, unique = true, updatable = false)
     private String uuid; // UUID 인증코드
 
-    // 공고 등록 시 uuid 생성, 공고등록step1이 없어서 테스트 못해봄! 11일에 할 예정, 아마 될거임
+    // 공고 등록 시 uuid 생성
     @PrePersist
     public void createUUID() {
         this.uuid = UUID.randomUUID().toString(); // UUID 자동 생성
@@ -84,10 +84,8 @@ public class Announcement { //공고
     @JoinColumn(name = "recruiter_idx")
     private Recruiter recruiter; // 채용담당자 외래키
 
-    // 기업 외래키 추가 필요
-
     @OneToMany(mappedBy = "announcement" ,fetch = FetchType.LAZY)
-    private List<CustomForm> CustomFormList = new ArrayList<>(); // 지원서 맞춤양식 테이블과 관계
+    private List<CustomForm> customFormList = new ArrayList<>(); // 지원서 맞춤양식 테이블과 관계
     @OneToMany(mappedBy = "announcement" ,fetch = FetchType.LAZY)
-    private List<CustomLetterForm> CustomLetterFormList = new ArrayList<>(); // 자기소개서 맞춤양식 테이블과 관계
+    private List<CustomLetterForm> customLetterFormList = new ArrayList<>(); // 자기소개서 맞춤양식 테이블과 관계
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/announce/service/AnnounceService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announce/service/AnnounceService.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,27 +40,27 @@ public class AnnounceService {
             String fileUrl,
             AnnounceRegisterReq dto) throws BaseException {
 
-        //채용담당자 확인
-        Optional<Recruiter> result = recruiterRepository.findByRecruiterIdx(recruiterIdx);
-        if(result.isPresent()) {
+        // 채용담당자 확인
+        Optional<Recruiter> resultRecruiter = recruiterRepository.findByRecruiterIdx(recruiterIdx);
+        if(resultRecruiter.isPresent()) {
             // 셀렉트 폼이 트루면 = 파일url이 있으면 파일만 공고 엔티티에 저장
             if(dto.getSelectForm()) {
                 Announcement announcement = Announcement.builder()
-                        .recruiter(result.get())
+                        .recruiter(resultRecruiter.get())
                         .selectForm(dto.getSelectForm())
                         .title(dto.getTitle())
                         .imgUrl(fileUrl)
                         .build();
                 announceRepository.save(announcement);
 
-                //응답
+                // 응답
                 return AnnounceRegisterRes.builder()
                         .announceIdx(announcement.getIdx())
                         .build();
 
             } else { // 셀렉트 폼이 폴스면 = 파일url이 없으면 들어온 dto만 저장
                 Announcement announcement = Announcement.builder()
-                        .recruiter(result.get())
+                        .recruiter(resultRecruiter.get())
                         .selectForm(dto.getSelectForm())
                         .title(dto.getTitle())
                         .jobCategory(dto.getJobCategoryList().toString())
@@ -81,13 +82,13 @@ public class AnnounceService {
                         .build();
                 announceRepository.save(announcement);
 
-                //응답
+                // 응답
                 return AnnounceRegisterRes.builder()
                         .announceIdx(announcement.getIdx())
                         .build();
             }
         } else {
-            //채용담당자 유저에서 찾을 수 없을 때
+            // 채용담당자 유저에서 찾을 수 없을 때
             throw new BaseException(BaseResponseMessage.ANNOUNCEMENT_REGISTER_STEP_ONE_FAIL_NOT_RECRUITER);
         }
     }
@@ -95,61 +96,54 @@ public class AnnounceService {
 
     /*******채용담당자 지원서 폼 조립 + 자기소개서 문항 등록 (step2)***********/
     public CustomFormRes registerCustomForm(CustomFormReq dto) throws BaseException {
-        //클라이언트에서 넣을 폼을 선택한다 -> dto에 그 폼의 코드값이 들어온다
+        // 클라이언트에서 넣을 폼을 선택 -> dto에 그 폼의 코드값이 들어옴
 
-        //예외 처리) 공고가 잘 저장되어 있는지 먼저 확인 필요
+        // 예외 처리) 공고가 잘 저장되어 있는지 먼저 확인 필요
         Optional<Announcement> resultAnnouncement = announceRepository.findByAnnounceIdx(dto.getAnnounceIdx());
-        if (resultAnnouncement.isPresent()) {
-            //리스트 길이만큼 커스텀 폼 엔티티 생성 후 저장
-            for(int i=0; i < dto.getCode().size(); i++) {
-                CustomForm customForm = CustomForm.builder()
-                        .code(dto.getCode().get(i))
-                        .announcement(resultAnnouncement.get())
-                        .build();
-                customFormRepository.save(customForm);
-            }
-
-            String groupName = "custom_form";
-            List<BaseInfo> resultBaseInfoList = baseInfoRepository.findAllByGroupName(groupName);
-
-            //저장 배열
-            List<Long> emsiIdx = new ArrayList<>();
-            List<String> emsiDes = new ArrayList<>();
-
-            for(int i=0; i < resultBaseInfoList.size(); i++) {
-                for(int j=0; j < dto.getCode().size(); j++) {
-                    if(Objects.equals(resultBaseInfoList.get(i).getCode() , dto.getCode().get(j))) {
-                        emsiIdx.add(resultBaseInfoList.get(i).getIdx());
-                        emsiDes.add(resultBaseInfoList.get(i).getDescription());
-                    }
-                }
-            }
-
-            // 추가한 자기소개서 문항 등록
-
-            // 저장 배열
-            List<Long> emsiLetterIdx = new ArrayList<>();
-
-            //리스트 길이만큼 커스텀 레터 폼 엔티티 생성 후 저장
-            for(int i=0; i < dto.getTitleList().size(); i++) {
-                CustomLetterForm customLetterForm = CustomLetterForm.builder()
-                        .title(dto.getTitleList().get(i))
-                        .chatLimit(dto.getChatLimitList().get(i))
-                        .announcement(resultAnnouncement.get())
-                        .build();
-                letterFormRepository.save(customLetterForm);
-                emsiLetterIdx.add(customLetterForm.getIdx());
-            }
-
-            //응답
-            return CustomFormRes.builder()
-                    .baseInfoIdxList(emsiIdx)
-                    .descriptionList(emsiDes)
-                    .customFormLetterIdList(emsiLetterIdx)
-                    .build();
-        } else {
+        if (!resultAnnouncement.isPresent()) {
             throw new BaseException(BaseResponseMessage.ANNOUNCEMENT_REGISTER_STEP_TWO_FAIL_NOT_FOUND);
         }
 
+        // 1. 리스트 길이만큼 커스텀 폼 엔티티 생성 후 저장
+        List<String> formCodes = dto.getCode();
+        for (String code : formCodes) {
+            CustomForm customForm = CustomForm.builder()
+                    .code(code)
+                    .announcement(resultAnnouncement.get())
+                    .build();
+            customFormRepository.save(customForm);
+        }
+
+        // 2. baseInfo 조회 - groupName과 code 리스트로 조회
+        String groupName = "custom_form";
+        List<BaseInfo> resultBaseInfoList = baseInfoRepository.findAllByGroupNameAndCodeIn(groupName, formCodes);
+
+        // 3. 저장 배열 생성 (인덱스와 설명 리스트)
+        List<Long> emsiIdx = resultBaseInfoList.stream()
+                .map(BaseInfo::getIdx)
+                .collect(Collectors.toList());
+
+        List<String> emsiDes = resultBaseInfoList.stream()
+                .map(BaseInfo::getDescription)
+                .collect(Collectors.toList());
+
+        // 4. 추가한 자기소개서 문항 등록 (리스트 길이만큼 커스텀 레터 폼 엔티티 생성 후 저장)
+        List<Long> emsiLetterIdx = new ArrayList<>();
+        for (int i = 0; i < dto.getTitleList().size(); i++) {
+            CustomLetterForm customLetterForm = CustomLetterForm.builder()
+                    .title(dto.getTitleList().get(i))
+                    .chatLimit(dto.getChatLimitList().get(i))
+                    .announcement(resultAnnouncement.get())
+                    .build();
+            letterFormRepository.save(customLetterForm);
+            emsiLetterIdx.add(customLetterForm.getIdx());
+        }
+
+        // 5. 응답 생성
+        return CustomFormRes.builder()
+                .baseInfoIdxList(emsiIdx)
+                .descriptionList(emsiDes)
+                .customFormLetterIdList(emsiLetterIdx)
+                .build();
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/data_init/repository/BaseInfoRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/data_init/repository/BaseInfoRepository.java
@@ -2,6 +2,8 @@ package com.sabujaks.irs.domain.data_init.repository;
 
 import com.sabujaks.irs.domain.data_init.entity.BaseInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +12,7 @@ import java.util.Optional;
 @Repository
 public interface BaseInfoRepository extends JpaRepository<BaseInfo, Long> {
     List<BaseInfo> findAllByGroupName(String groupName);
+
+    @Query("SELECT b FROM BaseInfo b WHERE b.groupName = :groupName AND b.code IN :codes")
+    List<BaseInfo> findAllByGroupNameAndCodeIn(@Param("groupName") String groupName, @Param("codes") List<String> codes);
 }

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -42,6 +42,7 @@ public enum BaseResponseMessage {
     VIDEO_INTERVIEW_SEARCH_ALL_FAIL_NOT_FOUND(false, 1402, "화상 면접방 목록 조회에 실패했습니다."),
     VIDEO_INTERVIEW_JOIN_SUCCESS(true, 1403, "화상 면접방에 참가했습니다."),
     VIDEO_INTERVIEW_JOIN_FAIL(false, 1404, "화상 면접방 참가에 실패했습니다."),
+
     // RESUME 2000~2999
     RESUME_REGISTER_SUCCESS(true, 2000, "지원서 등록에 성공했습니다."),
     RESUME_REGISTER_FAIL_NOT_FOUND(false, 2001, "해당 유저를 찾을 수 없습니다."),
@@ -50,11 +51,16 @@ public enum BaseResponseMessage {
 
     // ANNOUNCEMENT 3000~3999
     ANNOUNCEMENT_REGISTER_STEP_ONE_SUCCESS(true, 3000, "공고 등록에 성공했습니다."),
-    ANNOUNCEMENT_REGISTER_STEP_ONE_FAIL_NOT_RECRUITER(true, 3001, "채용담당자 유저가 아닙니다."),
-    ANNOUNCEMENT_REGISTER_STEP_ONE_FAIL(true, 3002, "공고 등록에 실패했습니다."),
+    ANNOUNCEMENT_REGISTER_STEP_ONE_FAIL_NOT_RECRUITER(false, 3001, "채용담당자 유저가 아닙니다."),
+    ANNOUNCEMENT_REGISTER_STEP_ONE_FAIL(false, 3002, "공고 등록에 실패했습니다."),
     ANNOUNCEMENT_REGISTER_STEP_TWO_SUCCESS(true, 3100, "지원서 폼 조립에 성공했습니다."),
     ANNOUNCEMENT_REGISTER_STEP_TWO_FAIL_NOT_FOUND(false, 3101, "공고가 저장되지 않아 찾을 수 없습니다."),
-    ANNOUNCEMENT_REGISTER_STEP_TWO_FAIL(false, 3102, "지원서 폼 조립에 실패하였습니다." );
+    ANNOUNCEMENT_REGISTER_STEP_TWO_FAIL(false, 3102, "지원서 폼 조립에 실패하였습니다." ),
+
+    // COMPANY 기업정보 관련 4000
+    COMPANY_INFO_SUCCESS(true, 4000, "기업 정보 등록에 성공했습니다."),
+    COMPANY_INFO_FAIL_NOT_RECRUITER(false, 4001, "채용담당자 유저가 아닙니다."),
+    COMPANY_INFO_FAIL(false, 4002, "기업 정보 등록에 실패했습니다.");
 
     private Boolean success;
     private Integer code;


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
#31
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게 보다 무엇을 왜 수정했는지 설명해주세요. -->
공고 등록 후 지원서 폼 등록 부분에서 중복되는 코드와 필요없는 반복문을 처리했음
base_info 테이블 조회 시 쓰는 쿼리문을 그룹이름과 코드로 한번에 조회하는 방식으로 개선함.
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
<br>

## ✅ 주요구현 기능
<!-- 
- 좋아요 추가 및 제거
- 좋아요 개수 확인
-->
공고 등록후 지원서 폼 조립 서비스 코드 개선
<br>

<br>

