### PR TITLE
[#133][Feat] 지원자 지원서 등록6 기능 개발 완료

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/controller/ResumeController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/controller/ResumeController.java
@@ -1,6 +1,7 @@
 package com.sabujaks.irs.domain.resume.controller;
 
 import com.sabujaks.irs.domain.resume.model.request.ResumeCreateReq;
+import com.sabujaks.irs.domain.resume.model.request.ResumeSubmitReq;
 import com.sabujaks.irs.domain.resume.model.response.ResumeCreateRes;
 import com.sabujaks.irs.domain.resume.service.ResumeService;
 import com.sabujaks.irs.global.common.exception.BaseException;
@@ -25,7 +26,7 @@ public class ResumeController {
     private final CloudFileUpload cloudFileUpload;
 
     // 마이페이지 -> 지원서 등록
-    @PostMapping("/create-mypage")
+    @PostMapping("/create")
     public ResponseEntity<BaseResponse<ResumeCreateReq>> create(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestPart ResumeCreateReq dto,
@@ -44,5 +45,21 @@ public class ResumeController {
     }
     
     // 공고 -> 지원서 등록
+    @PostMapping("/submit")
+    public ResponseEntity<BaseResponse<ResumeCreateReq>> submit(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestPart ResumeSubmitReq dto,
+            @RequestPart MultipartFile file) throws BaseException {
+        if (customUserDetails == null) throw new BaseException(BaseResponseMessage.AUTH_FAIL);
+        Long seekerIdx = customUserDetails.getIdx();
 
+        if(file.isEmpty()) {
+            throw new BaseException(BaseResponseMessage.RESUME_REGISTER_FAIL_NOT_FOUND_FILE);
+        }
+
+        String fileUrl = cloudFileUpload.upload(file);
+        ResumeCreateRes response = resumeService.submit(seekerIdx, dto, fileUrl);
+
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.RESUME_REGISTER_SUCCESS, response));
+    }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/model/entity/Resume.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/model/entity/Resume.java
@@ -7,6 +7,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Builder
@@ -18,6 +22,13 @@ public class Resume {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
+
+    @Column(nullable = false, length = 100)
+    private String resumeTitle;
+
+    @Column(nullable = false)
+    @CreationTimestamp
+    private LocalDateTime resumedAt;
 
     // 지원정보 테이블과 n:1
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/model/entity/ResumeInfo.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/model/entity/ResumeInfo.java
@@ -19,6 +19,9 @@ public class ResumeInfo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
 
+    @Column(nullable = false)
+    private Boolean integration;
+
     // 회원 테이블과 n:1
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seeker_idx")

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/model/request/ResumeSubmitReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/model/request/ResumeSubmitReq.java
@@ -1,0 +1,28 @@
+package com.sabujaks.irs.domain.resume.model.request;
+
+import lombok.*;
+
+import java.util.ArrayList;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResumeSubmitReq {
+    private Long announcementIdx;
+    private ArrayList<String> codes;
+    private String resumeTitle;
+    private PersonalInfoCreateReq personalInfo; // 인적사항 1개
+    private PreferentialEmpInfoCreateReq preferentialEmp; // 취업우대·병역 1개
+    private ArrayList<EducationCreateReq> educations; // 학력 n개
+    private ArrayList<PersonalHistoryCreateReq> personalHistories; // 경력 n개
+    private ArrayList<InternsActivityCreateReq> internsActivities; // 인턴·대외활동 n개
+    private ArrayList<StudyingAbroadCreateReq> studyingAbroads; // 해외경험 n개
+    private ArrayList<LanguageCreateReq> languages; // 어학 n개
+    private ArrayList<CertificationCreateReq> certifications; // 자격증 n개
+    private ArrayList<TrainingCreateReq> trainings; // 교육이수 n개
+    private ArrayList<AwardCreateReq> awards; // 수상 n개
+    private ArrayList<CustomLetterCreateReq> customLetters; // 자기소개서 n개
+    private ArrayList<PortfolioCreateReq> portfolios; // 포트폴리오 n개
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/repository/ResumeInfoRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/repository/ResumeInfoRepository.java
@@ -1,7 +1,13 @@
 package com.sabujaks.irs.domain.resume.repository;
 
+import com.sabujaks.irs.domain.auth.model.entity.Seeker;
 import com.sabujaks.irs.domain.resume.model.entity.ResumeInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface ResumeInfoRepository extends JpaRepository<ResumeInfo, Long> {
+    @Query("SELECT r FROM ResumeInfo r WHERE r.seeker.idx = :seekerIdx AND r.integration = :integration")
+    Optional<ResumeInfo> findBySeekerIdxAndIntegration(Long seekerIdx, Boolean integration);
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/service/ResumeService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/service/ResumeService.java
@@ -1,5 +1,7 @@
 package com.sabujaks.irs.domain.resume.service;
 
+import com.sabujaks.irs.domain.announce.model.entity.Announcement;
+import com.sabujaks.irs.domain.announce.repository.AnnounceRepository;
 import com.sabujaks.irs.domain.auth.model.entity.Seeker;
 import com.sabujaks.irs.domain.auth.repository.SeekerRepository;
 import com.sabujaks.irs.domain.resume.model.entity.*;
@@ -32,16 +34,24 @@ public class ResumeService {
     private final CustomLetterRepository customLetterRepository;
     private final PortfolioRepository portfolioRepository;
     private final CustomResumeInfoRepository customResumeInfoRepository;
+    private final AnnounceRepository announceRepository;
+    private final ResumeRepository resumeRepository;
 
 
     @Transactional
     public ResumeCreateRes create(Long seekerIdx, ResumeCreateReq dto, String fileUrl) throws BaseException {
         // 지원자 테이블 조회
-        Optional<Seeker> result = seekerRepository.findBySeekerIdx(seekerIdx);
-        if(result.isPresent()) {
+        Optional<Seeker> resultSeeker = seekerRepository.findBySeekerIdx(seekerIdx);
+        if(resultSeeker.isPresent()) {
+            // 통합지원서 저장 여부 파악 (해당 지원자가 통합 지원서를 작성한 적이 있는지)
+            Optional<ResumeInfo> resultResumeInfo = resumeInfoRepository.findBySeekerIdxAndIntegration(seekerIdx, true);
+            if(resultResumeInfo.isPresent()) {
+                throw new BaseException(BaseResponseMessage.RESUME_REGISTER_FAIL_INTEGRATION);
+            }
             // 지원정보 테이블에 저장
             ResumeInfo resumeInfo = ResumeInfo.builder()
-                    .seeker(result.get())
+                    .seeker(resultSeeker.get())
+                    .integration(true) // 통합지원서 - 1개만 가능
                     .build();
             resumeInfoRepository.save(resumeInfo);
 
@@ -231,7 +241,227 @@ public class ResumeService {
                     .resume_info_idx(resumeInfo.getIdx())
                     .build();
         } else {
-            throw new BaseException(BaseResponseMessage.RESUME_REGISTER_FAIL_NOT_FOUND);
+            throw new BaseException(BaseResponseMessage.RESUME_REGISTER_FAIL_NOT_FOUND_SEEKER);
+        }
+    }
+
+    @Transactional
+    public ResumeCreateRes submit(Long seekerIdx, ResumeSubmitReq dto, String fileUrl) throws BaseException {
+        // 지원자 테이블 조회
+        Optional<Seeker> resultSeeker = seekerRepository.findBySeekerIdx(seekerIdx);
+        if(resultSeeker.isPresent()) {
+            // 지원정보 테이블에 저장
+            ResumeInfo resumeInfo = ResumeInfo.builder()
+                    .seeker(resultSeeker.get())
+                    .integration(false)
+                    .build();
+            resumeInfoRepository.save(resumeInfo);
+
+            // 인적사항 테이블에 저장 (반드시)
+            PersonalInfo personalInfo = PersonalInfo.builder()
+                    .resumeInfo(resumeInfo)
+                    .name(dto.getPersonalInfo().getName())
+                    .birth(dto.getPersonalInfo().getBirth())
+                    .gender(dto.getPersonalInfo().getGender())
+                    .email(dto.getPersonalInfo().getEmail())
+                    .phone(dto.getPersonalInfo().getPhone())
+                    .tel(dto.getPersonalInfo().getTel())
+                    .address(dto.getPersonalInfo().getAddress())
+                    .profileImg(fileUrl)
+                    .build();
+            personalInfoRepository.save(personalInfo);
+
+            // 맞춤코드에 해당하는 테이블에 저장 후 지원정보 양식 테이블에 저장
+            for(String code : dto.getCodes()) {
+                if(code.equals("resume_001") && dto.getEducations() != null) {
+                    // 학력 테이블에 저장 (조건 필요)
+                    for(EducationCreateReq edu : dto.getEducations()) {
+                        Education education = Education.builder()
+                                .resumeInfo(resumeInfo)
+                                .highLess(edu.getHighLess())
+                                .schoolDiv(edu.getSchoolDiv())
+                                .schoolName(edu.getSchoolName())
+                                .enteredAt(edu.getEnteredAt())
+                                .graduatedAt(edu.getGraduatedAt())
+                                .graduationStatus(edu.getGraduationStatus())
+                                .majorName(edu.getMajorName())
+                                .grade(edu.getGrade())
+                                .totalGrade(edu.getTotalGrade())
+                                .transfer(edu.getTransfer())
+                                .majorType(edu.getMajorType())
+                                .otherMajor(edu.getOtherMajor())
+                                .graduationWork(edu.getGraduationWork())
+                                .degree(edu.getDegree())
+                                .qualificationExam(edu.getQualificationExam())
+                                .passedAt(edu.getPassedAt())
+                                .build();
+                        educationRepository.save(education);
+                    }
+                } else if(code.equals("resume_002") && dto.getPersonalHistories() != null) {
+                    // 경력 테이블에 저장 (조건 필요)
+                    for(PersonalHistoryCreateReq ph : dto.getPersonalHistories()) {
+                        PersonalHistory personalHistory = PersonalHistory.builder()
+                                .resumeInfo(resumeInfo)
+                                .companyName(ph.getCompanyName())
+                                .deptName(ph.getDeptName())
+                                .enteredAt(ph.getEnteredAt())
+                                .quitAt(ph.getQuitAt())
+                                .empStatus(ph.getEmpStatus())
+                                .position(ph.getPosition())
+                                .job(ph.getJob())
+                                .salary(ph.getSalary())
+                                .work(ph.getWork())
+                                .build();
+                        personalHistoryRepository.save(personalHistory);
+                    }
+
+                } else if(code.equals("resume_003") && dto.getInternsActivities() != null) {
+                    // 인턴·대외활동 테이블에 저장 (조건 필요)
+                    for(InternsActivityCreateReq ia : dto.getInternsActivities()) {
+                        InternsActivity internsActivity = InternsActivity.builder()
+                                .resumeInfo(resumeInfo)
+                                .activityDiv(ia.getActivityDiv())
+                                .organization(ia.getOrganization())
+                                .startAt(ia.getStartAt())
+                                .endAt(ia.getEndAt())
+                                .contents(ia.getContents())
+                                .build();
+                        internActivitiesRepository.save(internsActivity);
+                    }
+                } else if(code.equals("resume_004") && dto.getTrainings() != null) {
+                    // 교육이수 테이블에 저장 (조건 필요) resume_004
+                    for(TrainingCreateReq t : dto.getTrainings()) {
+                        Training training = Training.builder()
+                                .resumeInfo(resumeInfo)
+                                .trainingName(t.getTrainingName())
+                                .organization(t.getOrganization())
+                                .startAt(t.getStartAt())
+                                .endAt(t.getEndAt())
+                                .contents(t.getContents())
+                                .build();
+                        trainingRepository.save(training);
+                    }
+                } else if(code.equals("resume_005") && dto.getCertifications() != null) {
+                    // 자격증 테이블에 저장 (조건 필요) resume_005
+                    for(CertificationCreateReq c : dto.getCertifications()) {
+                        Certification certification = Certification.builder()
+                                .resumeInfo(resumeInfo)
+                                .certName(c.getCertName())
+                                .organization(c.getOrganization())
+                                .takingAt(c.getTakingAt())
+                                .build();
+                        certificationRepository.save(certification);
+                    }
+                } else if(code.equals("resume_006") && dto.getAwards() != null) {
+                    // 수상 테이블에 저장 (조건 필요) resume_006
+                    for(AwardCreateReq a : dto.getAwards()) {
+                        Award award = Award.builder()
+                                .resumeInfo(resumeInfo)
+                                .awardName(a.getAwardName())
+                                .contents(a.getContents())
+                                .organization(a.getOrganization())
+                                .year(a.getYear())
+                                .build();
+                        awardRepository.save(award);
+                    }
+                } else if(code.equals("resume_007") && dto.getStudyingAbroads() != null) {
+                    // 해외경험 테이블에 저장 (조건 필요) resume_007
+                    for(StudyingAbroadCreateReq sa : dto.getStudyingAbroads()) {
+                        StudyingAbroad studyingAbroad = StudyingAbroad.builder()
+                                .resumeInfo(resumeInfo)
+                                .countryName(sa.getCountryName())
+                                .startAt(sa.getStartAt())
+                                .endAt(sa.getEndAt())
+                                .contents(sa.getContents())
+                                .build();
+                        studyingAboardRepository.save(studyingAbroad);
+                    }
+                } else if(code.equals("resume_008") && dto.getLanguages() != null) {
+                    // 어학 테이블에 저장 (조건 필요) resume_008
+                    for(LanguageCreateReq l : dto.getLanguages()) {
+                        Language language = Language.builder()
+                                .resumeInfo(resumeInfo)
+                                .testDiv(l.getTestDiv())
+                                .languageName(l.getLanguageName())
+                                .conversationLevel(l.getConversationLevel())
+                                .officialTest(l.getOfficialTest())
+                                .score(l.getScore())
+                                .takingAt(l.getTakingAt())
+                                .build();
+                        languageRepository.save(language);
+                    }
+                } else if(code.equals("resume_009") && dto.getPortfolios() != null) {
+                    // 포트폴리오 테이블에 저장 (조건 필요) resume_009
+                    for(PortfolioCreateReq p : dto.getPortfolios()) {
+                        Portfolio portfolio = Portfolio.builder()
+                                .resumeInfo(resumeInfo)
+                                .portfolioDiv(p.getPortfolioDiv())
+                                .portfolioUrl(p.getPortfolioUrl())
+                                .build();
+                        portfolioRepository.save(portfolio);
+                    }
+                } else if(code.equals("resume_010") && dto.getPreferentialEmp() != null) {
+                    // 취업우대&병역에 저장 (조건 필요) resume_010
+                    PreferentialEmp preferentialEmp = PreferentialEmp.builder()
+                            .resumeInfo(resumeInfo)
+                            .veterans(dto.getPreferentialEmp().getVeterans())
+                            .protection(dto.getPreferentialEmp().getProtection())
+                            .subsidy(dto.getPreferentialEmp().getSubsidy())
+                            .disability(dto.getPreferentialEmp().getDisability())
+                            .disabilityDegree(dto.getPreferentialEmp().getDisabilityDegree())
+                            .military(dto.getPreferentialEmp().getMilitary())
+                            .militaryClass(dto.getPreferentialEmp().getMilitaryClass())
+                            .militaryStart(dto.getPreferentialEmp().getMilitaryStart())
+                            .militaryEnd(dto.getPreferentialEmp().getMilitaryEnd())
+                            .militaryType(dto.getPreferentialEmp().getMilitaryType())
+                            .militaryRank(dto.getPreferentialEmp().getMilitaryRank())
+                            .build();
+                    preferentialEmpRepository.save(preferentialEmp);
+                } else if(code.equals("resume_011") && dto.getCustomLetters() != null) {
+                    // 자기소개서 테이블에 저장 (조건 필요) resume_011
+                    for(CustomLetterCreateReq cl : dto.getCustomLetters()) {
+                        CustomLetter customLetter = CustomLetter.builder()
+                                .resumeInfo(resumeInfo)
+                                .title(cl.getTitle())
+                                .charLimit(cl.getCharLimit())
+                                .contents(cl.getContents())
+                                .build();
+                        customLetterRepository.save(customLetter);
+                    }
+                } else {
+                    throw new BaseException(BaseResponseMessage.RESUME_REGISTER_FAIL);
+                }
+
+                CustomResumeInfo customResumeInfo = CustomResumeInfo.builder()
+                        .resumeInfo(resumeInfo)
+                        .code(code)
+                        .build();
+                customResumeInfoRepository.save(customResumeInfo);
+            }
+
+
+            // 공고 idx로 공고 조회
+            Optional<Announcement> resultAnnouncement = announceRepository.findByAnnounceIdx(dto.getAnnouncementIdx());
+            if(resultAnnouncement.isPresent()) {
+                // 공고지원서 테이블에 저장
+                Resume resume = Resume.builder()
+                        .resumeTitle(dto.getResumeTitle())
+                        .resumeInfo(resumeInfo)
+                        .announcement(resultAnnouncement.get())
+                        .seeker(resultSeeker.get())
+                        .build();
+                resumeRepository.save(resume);
+
+
+                return ResumeCreateRes.builder()
+                        .resume_info_idx(resumeInfo.getIdx())
+                        .build();
+            } else {
+                throw new BaseException(BaseResponseMessage.RESUME_REGISTER_FAIL_NOT_FOUND_ANNOUNCE);
+            }
+
+        } else {
+            throw new BaseException(BaseResponseMessage.RESUME_REGISTER_FAIL_NOT_FOUND_SEEKER);
         }
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -51,9 +51,11 @@ public enum BaseResponseMessage {
 
     // RESUME 2000~2999
     RESUME_REGISTER_SUCCESS(true, 2000, "지원서 등록에 성공했습니다."),
-    RESUME_REGISTER_FAIL_NOT_FOUND(false, 2001, "해당 유저를 찾을 수 없습니다."),
-    RESUME_REGISTER_FAIL_NOT_FOUND_FILE(false, 2002, "파일을 찾을 수 없습니다."),
-    RESUME_REGISTER_FAIL(false, 2003, "지원서 등록에 실패하였습니다." ),
+    RESUME_REGISTER_FAIL_NOT_FOUND_ANNOUNCE(false, 2001, "해당 공고를 찾을 수 없습니다."),
+    RESUME_REGISTER_FAIL_INTEGRATION(false, 2002, "통합 지원서가 이미 존재합니다."),
+    RESUME_REGISTER_FAIL_NOT_FOUND_SEEKER(false, 2003, "해당 유저를 찾을 수 없습니다."),
+    RESUME_REGISTER_FAIL_NOT_FOUND_FILE(false, 2004, "파일을 찾을 수 없습니다."),
+    RESUME_REGISTER_FAIL(false, 2005, "지원서 등록에 실패하였습니다." ),
 
     // ANNOUNCEMENT 3000~3999
     ANNOUNCEMENT_REGISTER_STEP_ONE_SUCCESS(true, 3000, "공고 등록에 성공했습니다."),


### PR DESCRIPTION
## 💭 연관된 이슈
closed: #133
<!-- #1 -->
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
지원자 지원서 등록 6 기능 개발 완료

<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
<br>

## ✅ 주요구현 기능
1. 마이페이지 -> 지원서등록 (통합 지원서)
통합 지원서 등록 여부 확인(1개만 가능) -> 지원 정보 저장 -> 인적사항 저장 -> (반복) 맞춤코드에 해당하는 각 테이블에 정보 저장 후 맞춤 지원정보 저장

* 지원정보 테이블에 통합 지원서인지 아닌지 파악을 위해 통합여부 컬럼 추가

2. 공고 상세 -> 지원서등록
지원 정보 저장 -> 인적사항 저장 -> (반복) 맞춤코드에 해당하는 각 테이블에 정보 저장 후 맞춤 지원정보 저장 -> 공고지원서 저장

* 공고지원서 테이블에 지원서 제목, 지원 날짜 컬럼 추가

<!-- 
- 좋아요 추가 및 제거
- 좋아요 개수 확인
-->
<br>

<br>

