### PR TITLE
[#27][Feat] 회원 탈퇴 개발

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/controller/AnnouncementController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/controller/AnnouncementController.java
@@ -71,7 +71,7 @@ public class AnnouncementController {
 //        Long recruiterIdx = customUserDetails.getIdx();
         RecruiterInfoReadRes response = announcementService.readRecruiterInfo(recruiterIdx);
 
-        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.MEMBER_SEARCH_USER_INFO_SUCCESS, response));
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.AUTH_SEARCH_USER_INFO_SUCCESS, response));
     }
 
 

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/controller/AuthController.java
@@ -38,14 +38,18 @@ public class AuthController {
         AuthSignupRes response = authService.signup(dto, fileUrl);
         String uuid = emailVerifyService.sendMail(response);
         emailVerifyService.save(dto.getEmail(), uuid);
-        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.AUTH_REGISTER_SUCCESS, response));
+        if(response.getInactive()){
+            return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.AUTH_RESTORE_SUCCESS, response));
+        }else{
+            return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.AUTH_REGISTER_SUCCESS, response));
+        }
     }
 
     @GetMapping("/email-verify")
     public ResponseEntity<BaseResponse> emailVerify(
         String email, String role, String uuid) throws Exception, BaseException {
         if(emailVerifyService.isExist(email, uuid)){
-            authService.activeMember(email, role);
+            authService.activeUser(email, role);
             return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.AUTH_EMAIL_VERIFY_SUCCESS));
         } else {
             return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.AUTH_EMAIL_VERIFY_FAIL));
@@ -72,5 +76,12 @@ public class AuthController {
         @RequestBody PasswordEditReq dto) throws BaseException {
         authService.editPassword(customUserDetails, dto);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.AUTH_EDIT_PASSWORD_SUCCESS));
+    }
+
+    @GetMapping("/inactive-user")
+    public ResponseEntity<BaseResponse> inactiveUser(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+        authService.inactiveUser(customUserDetails);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.AUTH_INACTIVE_USER_SUCCESS));
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/repository/EmailVerifyRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/repository/EmailVerifyRepository.java
@@ -2,9 +2,15 @@ package com.sabujaks.irs.domain.auth.repository;
 
 import com.sabujaks.irs.domain.auth.model.entity.EmailVerify;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface EmailVerifyRepository extends JpaRepository<EmailVerify, Long> {
     Optional<EmailVerify> findByEmail(String email);
+
+    @Modifying
+    @Query("DELETE FROM EmailVerify ev WHERE ev.email = :email")
+    int deleteByEmail(String email);
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/service/EmailVerifyService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/service/EmailVerifyService.java
@@ -45,13 +45,13 @@ public class EmailVerifyService {
             if(!response.getEmail_auth() && !response.getInactive()){
                 message.setSubject("IRS - 채용 담당자로 가입하신걸 환영합니다.");
             } else {
-                message.setSubject("IRS - 채용 담당자 계정 복구 이메일");
+                message.setSubject("IRS - 채용 담당자 계정 복구 이메일 검증");
             }
         } else if (Objects.equals(response.getRole(), "ROLE_SEEKER")) {
             if(!response.getEmail_auth() && !response.getInactive()){
                 message.setSubject("IRS - 지원자로 가입하신걸 환영합니다.");
             } else {
-                message.setSubject("IRS - 지원자 계정 복구 이메일");
+                message.setSubject("IRS - 지원자 계정 복구 이메일 검증");
             }
         } else {
             throw new BaseException(BaseResponseMessage.AUTH_EMAIL_VERIFY_FAIL_INVALID_ROLE);

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/service/InterviewEvaluateService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/service/InterviewEvaluateService.java
@@ -1,7 +1,7 @@
 package com.sabujaks.irs.domain.interview_evaluate.service;
 
 import com.sabujaks.irs.domain.announcement.model.entity.Announcement;
-import com.sabujaks.irs.domain.announcement.repository.AnnounceRepository;
+import com.sabujaks.irs.domain.announcement.repository.AnnouncementRepository;
 import com.sabujaks.irs.domain.interview_evaluate.model.entity.InterviewEvaluateForm;
 import com.sabujaks.irs.domain.interview_evaluate.model.request.InterviewEvaluateFormCreateReq;
 import com.sabujaks.irs.domain.interview_evaluate.model.response.InterviewEvaluateFormCreateRes;
@@ -21,10 +21,10 @@ public class InterviewEvaluateService {
     private final InterviewEvaluateRepository interviewEvaluateRepository;
     private final InterviewEvaluateFormRepository interviewEvaluateFormRepository;
     private final InterviewEvaluateResultRepository interviewEvaluateResultRepository;
-    private final AnnounceRepository announceRepository;
+    private final AnnouncementRepository announcementRepository;
 
     public InterviewEvaluateFormCreateRes createForm (InterviewEvaluateFormCreateReq dto) throws BaseException {
-        Announcement announcement = announceRepository.findByAnnounceIdx(dto.getAnnounceIdx())
+        Announcement announcement = announcementRepository.findByAnnounceIdx(dto.getAnnounceIdx())
         .orElseThrow(() -> new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL));
         Optional<InterviewEvaluateForm> result = interviewEvaluateRepository.findByAnnounceIdx(dto.getAnnounceIdx());
         if(result.isEmpty()){

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -19,10 +19,12 @@ public enum BaseResponseMessage {
     // AUTH 1000~1999
     // 회원가입 1000
     AUTH_REGISTER_SUCCESS(true, 1000, "회원가입에 성공했습니다. 이메일 인증 후 로그인 해주세요"),
-    AUTH_REGISTER_FAIL_MEMBER_ALREADY_EXITS(false, 1001, "이미 다른 계정이 존재합니다." ),
+    AUTH_REGISTER_FAIL_USER_ALREADY_EXITS(false, 1001, "이미 다른 계정이 존재합니다." ),
     AUTH_REGISTER_FAIL_INVALID_ROLE(false, 1002, "유효하지 않은 회원가입입니다. "),
     AUTH_REGISTER_FAIL_NOT_COMPANY_AUTH(false, 1003, "기업 인증을 하지 않은 사용자는 가입할 수 없습니다."),
-
+    AUTH_REGISTER_FAIL_ALREADY_REGISTER_AS_SEEKER(false, 1004, "이미 지원자 회원으로 가입된 계정입니다. 지원자 회원은 채용담당자 회원으로 회원가입 할 수 없습니다."),
+    AUTH_REGISTER_FAIL_ALREADY_REGISTER_AS_RECRUITER(false, 1004, "이미 채용담당자 회원으로 가입된 계정입니다. 채용담당자 회원은 지원자 회원으로 회원가입 할 수 없습니다."),
+    AUTH_RESTORE_SUCCESS(true, 1010, "비활성화된 계정입니다. 복구 절차로 이메일 인증을 해주세요"),
     // 이메일 검증 1100
     AUTH_EMAIL_VERIFY_SUCCESS(true, 1100, "이메일 검증을 완료했습니다."),
     AUTH_EMAIL_VERIFY_FAIL(false, 1101, "이메일 검증을 실패했습니다."),
@@ -42,6 +44,10 @@ public enum BaseResponseMessage {
     AUTH_EDIT_PASSWORD_SUCCESS(true, 1400, "계정 비밀번호 변경에 성공했습니다."),
     AUTH_EDIT_PASSWORD_FAIL_PASSWORD_NOT_MATCH(false, 1401, "계정 패스워드가 다릅니다."),
     AUTH_EDIT_PASSWORD_FAIL(false, 1402, "계정 비밀번호 변경에 실패했습니다."),
+
+    // 계정 비활성화 1500
+    AUTH_INACTIVE_USER_SUCCESS(true, 1500, "계정 비활성화에 성공했습니다."),
+    AUTH_INACTIVE_USER_FAIL(false, 1501, "계정 비활성화에 실패했습니다."),
 
     // INTERVIEW_SCHEDULE 면접 일정 1300
     INTERVIEW_SCHEDULE_CREATE_SUCCESS(true, 1300, "면접 일정 등록에 성공했습니다."),


### PR DESCRIPTION
## 💭 연관된 이슈
closed #27 
<br>
## 📌 구현 목표
회원 비활성화(탈퇴) 기능 개발
<br>

## ✅ 주요구현 기능
1. AuthService에 editPassword 메소드 추가, CustomUserDetails의 ROLE로 채용담당자, 지원자에 대해 회원 탈퇴 기능 개발
2. 지원자, 채용담당자의 계정을 비활성화
3. 계정 비활성화시(enabled(0) inactive(1)
4. 재 회원가입 시: enabled(0) inactive(0)
5. 소셜로그인시: 이메일 검증 값은 지우지 않음
6. 검증 이메일 전송 서비스 변경(계정복구와 신규회원가입을 나눔)
7. 회원가입 서비스 및 응답 변경