### PR TITLE
[#191][Feat] 면접일정 공고 리스트 조회 & 면접 리스트 조회

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/controller/AnnouncementController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/controller/AnnouncementController.java
@@ -89,4 +89,15 @@ public class AnnouncementController {
         AnnouncementReadDetailRes response = announcementService.readDetailSee(announcementIdx);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.ANNOUNCEMENT_SEARCH_SUCCESS, response));
     }
+
+    @GetMapping("/recruiter/read-all")
+    public ResponseEntity<BaseResponse<AnnouncementReadAllRes>> readAllAnnouncement(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam String careerBase) throws BaseException {
+        if (customUserDetails == null) throw new BaseException(BaseResponseMessage.AUTH_FAIL);
+        Long recruiterIdx = customUserDetails.getIdx();
+        List<AnnouncementReadAllRes2> response = announcementService.readAllAnnouncement(recruiterIdx, careerBase);
+
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.ANNOUNCEMENT_READ_ALL_SUCCESS, response));
+    }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/model/response/AnnouncementReadAllRes2.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/model/response/AnnouncementReadAllRes2.java
@@ -1,0 +1,54 @@
+package com.sabujaks.irs.domain.announcement.model.response;
+
+import com.sabujaks.irs.domain.auth.model.response.RecruiterRes;
+import lombok.Builder;
+import lombok.Data;
+
+
+@Data
+@Builder
+public class AnnouncementReadAllRes2 {
+    private Long idx;
+
+    // 공고 기본 설정
+    private String title;
+    private Boolean selectForm;
+    private String imgUrl;
+
+    // 모집분야
+    private String jobCategory;
+    private String jobTitle;
+    private Integer recruitedNum;
+    private String careerBase;
+    private String positionQuali;
+
+    // 지원자격/근무조건
+    private String region;
+    private String jobType;
+    private String salary;
+    private String conditions;
+
+    // 기업 복리후생
+    private String benefits;
+
+    // 인사담당자/기업정보
+    private String managerName;
+    private String managerContact;
+    private String managerEmail;
+    private String intro;
+
+    // 채용절차
+    private String announcementStart;
+    private String announcementEnd;
+    private Integer interviewNum;
+    private String process;
+
+    // 유의사항
+    private String note;
+
+    // UUID 인증코드
+    private String uuid;
+
+    // 관계 데이터
+    private RecruiterRes recruiterRes;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/repository/AnnouncementRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/repository/AnnouncementRepository.java
@@ -4,6 +4,7 @@ import com.sabujaks.irs.domain.announcement.model.entity.Announcement;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
@@ -12,4 +13,7 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
 
     @Query("SELECT a FROM Announcement a WHERE a.uuid = :announcementUUID")
     Optional<Announcement> findByAnnouncementUUID(String announcementUUID);
+
+    @Query("SELECT a FROM Announcement a WHERE a.recruiter.idx = :recruiterIdx AND a.careerBase=:careerBase")
+    Optional<List<Announcement>> findByRecruiterIdxAndCareerBase(Long recruiterIdx, String careerBase);
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/service/AnnouncementService.java
@@ -10,6 +10,7 @@ import com.sabujaks.irs.domain.announcement.repository.AnnouncementRepository;
 import com.sabujaks.irs.domain.announcement.repository.CustomFormRepository;
 import com.sabujaks.irs.domain.announcement.repository.CustomLetterFormRepository;
 import com.sabujaks.irs.domain.auth.model.entity.Recruiter;
+import com.sabujaks.irs.domain.auth.model.response.RecruiterRes;
 import com.sabujaks.irs.domain.auth.repository.RecruiterRepository;
 import com.sabujaks.irs.domain.company.model.entity.Company;
 import com.sabujaks.irs.domain.company.repository.CompanyBenefitsRepository;
@@ -345,5 +346,42 @@ public class AnnouncementService {
             // 공고 정보가 없을 때
             throw new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL);
         }
+    }
+
+    public List<AnnouncementReadAllRes2> readAllAnnouncement(Long recruiterIdx, String careerBase) throws BaseException {
+        Optional<Recruiter> recruiter = recruiterRepository.findByRecruiterIdx(recruiterIdx);
+        Optional<List<Announcement>> result = announcementRepository.findByRecruiterIdxAndCareerBase(recruiterIdx, careerBase);
+
+        List<AnnouncementReadAllRes2> announcementList = new ArrayList<>();
+        for(Announcement announcement : result.get()) {
+            announcementList.add(AnnouncementReadAllRes2.builder()
+                    .idx(announcement.getIdx())
+                    .title(announcement.getTitle())
+                    .selectForm(announcement.getSelectForm())
+                    .imgUrl(announcement.getImgUrl())
+                    .jobCategory(announcement.getJobCategory())
+                    .jobTitle(announcement.getJobTitle())
+                    .recruitedNum(announcement.getRecruitedNum())
+                    .careerBase(announcement.getCareerBase())
+                    .positionQuali(announcement.getPositionQuali())
+                    .region(announcement.getRegion())
+                    .jobType(announcement.getJobType())
+                    .salary(announcement.getSalary())
+                    .conditions(announcement.getConditions())
+                    .benefits(announcement.getBenefits())
+                    .announcementStart(announcement.getAnnouncementStart())
+                    .announcementEnd(announcement.getAnnouncementEnd())
+                    .interviewNum(announcement.getInterviewNum())
+                    .process(announcement.getProcess())
+                    .note(announcement.getNote())
+                    .uuid(announcement.getUuid())
+                    .recruiterRes(RecruiterRes.builder()
+                            .email(recruiter.get().getEmail())
+                            .name(recruiter.get().getName())
+                            .build())
+                    .build());
+        }
+
+        return announcementList;
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/response/RecruiterRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/response/RecruiterRes.java
@@ -1,0 +1,12 @@
+package com.sabujaks.irs.domain.auth.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class RecruiterRes {
+    private Long idx;
+    private String name;
+    private String email;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/response/SeekerInfoGetRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/response/SeekerInfoGetRes.java
@@ -1,0 +1,14 @@
+package com.sabujaks.irs.domain.auth.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class SeekerInfoGetRes {
+
+    private Long idx;
+
+    private String name;
+    private String email;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/data_init/DataInit.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/data_init/DataInit.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
-@Component
+//@Component
 public class DataInit {
     private final BaseInfoRepository baseInfoRepository;
     private final TeamRepository teamRepository;

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/controller/InterviewScheduleController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/controller/InterviewScheduleController.java
@@ -25,28 +25,22 @@ public class InterviewScheduleController {
     private final InterviewScheduleService interviewScheduleService;
     private final EmailSender emailSender;
 
-//    @PostMapping("/create")
-//    public ResponseEntity<BaseResponse<InterviewScheduleReq>> create (
-//        @AuthenticationPrincipal CustomUserDetails customUserDetails,
-//        @RequestBody InterviewScheduleReq dto) throws BaseException {
-//        InterviewScheduleRes response = interviewScheduleService.create(customUserDetails, dto);
-//        emailSender.sendEmail(response, dto.getEstimatorList());
-//        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.INTERVIEW_SCHEDULE_CREATE_SUCCESS, response));
-//    }
-
     @PostMapping("/create")
     public ResponseEntity<BaseResponse<InterviewScheduleReq>> create (
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody InterviewScheduleReq dto) throws BaseException {
-        InterviewScheduleRes response = interviewScheduleService.create(dto);
+        InterviewScheduleRes response = interviewScheduleService.create(customUserDetails, dto);
         emailSender.sendEmail(response, dto.getEstimatorList());
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.INTERVIEW_SCHEDULE_CREATE_SUCCESS, response));
     }
 
-    @GetMapping("/read-all/exp")
-    public ResponseEntity<BaseResponse<?>> readAllExp (){
-        List<InterviewScheduleRes> response = interviewScheduleService.readAllExp();
+    @GetMapping("/read-all")
+    public ResponseEntity<BaseResponse<?>> readAll (
+            @RequestParam String careerBase,
+            @RequestParam Long announcementIdx){
+        List<InterviewScheduleRes> response = interviewScheduleService.readAll(careerBase, announcementIdx);
 
-        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.INTERVIEW_SCHEDULE_CREATE_SUCCESS, response));
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.INTERVIEW_SCHEDULE_READ_ALL_SUCCESS, response));
     }
 
     // CustomUserDetail 추가하기

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/InterviewSchedule.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/InterviewSchedule.java
@@ -56,4 +56,8 @@ public class InterviewSchedule {
   
     @OneToMany(mappedBy = "interviewSchedule", fetch = FetchType.LAZY)
     private List<InterviewEvaluate> interviewEvaluateList;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="team_idx")
+    private Team team;
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/Team.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/Team.java
@@ -23,4 +23,7 @@ public class Team {
 
     @OneToMany(mappedBy = "team")
     private List<InterviewParticipate> interviewParticipateList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "team")
+    private List<InterviewSchedule> interviewSchedule;
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/response/InterviewParticipateReadRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/response/InterviewParticipateReadRes.java
@@ -1,0 +1,10 @@
+package com.sabujaks.irs.domain.interview_schedule.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class InterviewParticipateReadRes {
+    private Long seekerIdx;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/response/InterviewScheduleRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/response/InterviewScheduleRes.java
@@ -1,5 +1,6 @@
 package com.sabujaks.irs.domain.interview_schedule.model.response;
 
+import com.sabujaks.irs.domain.auth.model.response.SeekerInfoGetRes;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,11 +10,12 @@ import java.util.List;
 @Getter
 public class InterviewScheduleRes {
     private Long idx;
-    private List<Long> seekerList;
+    private List<SeekerInfoGetRes> seekerList;
     private List<String> estimatorList;
     private Boolean isOnline;
     private String interviewDate;
     private String interviewStart;
     private String interviewEnd;
     private String uuid;
+    private Long teamIdx;
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/repository/InterviewParticipateRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/repository/InterviewParticipateRepository.java
@@ -8,9 +8,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface InterviewParticipateRepository extends JpaRepository<InterviewParticipate, Long> {
-    @Query("SELECT ip FROM InterviewParticipate ip WHERE estimator.idx = :estimatorIdx AND interviewSchedule.uuid = :interviewScheduleUUID")
+    @Query("SELECT ip FROM InterviewParticipate ip WHERE ip.estimator.idx = :estimatorIdx AND ip.interviewSchedule.uuid = :interviewScheduleUUID")
     Optional<List<InterviewParticipate>> findFirstByEstimatorIdxAndInterviewScheduleUUID(Long estimatorIdx, String interviewScheduleUUID);
 
-    @Query("SELECT ip FROM InterviewParticipate ip WHERE estimator.idx = :estimatorIdx AND interviewSchedule.uuid = :interviewScheduleUUID")
+    @Query("SELECT ip FROM InterviewParticipate ip WHERE ip.estimator.idx = :estimatorIdx AND ip.interviewSchedule.uuid = :interviewScheduleUUID")
     Optional<List<InterviewParticipate>> findAllByEstimatorIdxAndInterviewScheduleUUID(Long estimatorIdx, String interviewScheduleUUID);
+
+    List<InterviewParticipate> findByInterviewScheduleIdx(Long interviewScheduleIdx);
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/repository/InterviewScheduleRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/repository/InterviewScheduleRepository.java
@@ -15,6 +15,9 @@ public interface InterviewScheduleRepository extends JpaRepository<InterviewSche
     List<InterviewSchedule> findByInterviewDate(String interviewDate);
     List<InterviewSchedule> findByCareerBase(String careerBase);
 
+    @Query("SELECT s FROM InterviewSchedule s WHERE s.careerBase = :careerBase AND s.announcement.idx = :announcementIdx")
+    Optional<List<InterviewSchedule>> findByCareerBaseAndAnnouncementIdx(String careerBase, Long announcementIdx);
+
     @Query("SELECT s FROM InterviewSchedule s WHERE s.idx = :interviewScheduleIdx")
     Optional<InterviewSchedule> findByInterviewScheduleIdx(Long interviewScheduleIdx);
 

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/service/InterviewScheduleService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/service/InterviewScheduleService.java
@@ -5,6 +5,7 @@ import com.sabujaks.irs.domain.alarm.repository.AlarmRepository;
 import com.sabujaks.irs.domain.announcement.model.entity.Announcement;
 import com.sabujaks.irs.domain.announcement.repository.AnnouncementRepository;
 import com.sabujaks.irs.domain.auth.model.entity.Seeker;
+import com.sabujaks.irs.domain.auth.model.response.SeekerInfoGetRes;
 import com.sabujaks.irs.domain.interview_schedule.model.entity.*;
 import com.sabujaks.irs.domain.auth.model.entity.Estimator;
 import com.sabujaks.irs.domain.auth.model.entity.Recruiter;
@@ -13,6 +14,7 @@ import com.sabujaks.irs.domain.auth.repository.RecruiterRepository;
 import com.sabujaks.irs.domain.auth.repository.SeekerRepository;
 import com.sabujaks.irs.domain.interview_schedule.model.request.InterviewScheduleReq;
 import com.sabujaks.irs.domain.interview_schedule.model.request.ReScheduleReq;
+import com.sabujaks.irs.domain.interview_schedule.model.response.InterviewParticipateReadRes;
 import com.sabujaks.irs.domain.interview_schedule.model.response.InterviewScheduleRes;
 import com.sabujaks.irs.domain.interview_schedule.model.response.ReScheduleRes;
 import com.sabujaks.irs.domain.interview_schedule.repository.InterviewParticipateRepository;
@@ -21,6 +23,7 @@ import com.sabujaks.irs.domain.interview_schedule.repository.ReScheduleRepositor
 import com.sabujaks.irs.domain.interview_schedule.repository.TeamRepository;
 import com.sabujaks.irs.global.common.exception.BaseException;
 import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
+import com.sabujaks.irs.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -42,76 +45,11 @@ public class InterviewScheduleService {
     private final AlarmRepository alarmRepository;
     private final ReScheduleRepository reScheduleRepository;
 
-//    public InterviewScheduleRes create(CustomUserDetails customUserDetails, InterviewScheduleReq dto) throws BaseException {
-//        String uuid = UUID.randomUUID().toString();
-//        Recruiter recruiter = recruiterRepository.findByRecruiterIdx(customUserDetails.getIdx())
-//        .orElseThrow(() -> new BaseException(BaseResponseMessage.MEMBER_NOT_FOUND));
-//        Announcement announcement = announceRepository.findByAnnounceIdx(dto.getAnnouncementIdx())
-//        .orElseThrow(() -> new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL));
-//        Team team = teamRepository.findByIdx(dto.getTeamIdx())
-//        .orElseThrow(() -> new BaseException(BaseResponseMessage.TEAM_NOT_FOUND));
-//
-//        InterviewSchedule interviewSchedule = InterviewSchedule.builder()
-//                .announcement(announcement)
-//                .recruiter(recruiter)
-//                .isOnline(dto.getIsOnline())
-//                .interviewDate(dto.getInterviewDate())
-//                .interviewStart(dto.getInterviewStart())
-//                .interviewEnd(dto.getInterviewEnd())
-//                .uuid(uuid)
-//                .careerBase(dto.getCareerBase())
-//                .recruiter(recruiter)
-//                .announcement(announcement)
-//                .build();
-//        interviewScheduleRepository.save(interviewSchedule);
-//
-//        List<Estimator> estimatorList = new ArrayList<>();
-//        List<Seeker> seekerList = new ArrayList<>();
-//        List<String> estimatorPasswordList = new ArrayList<>();
-//        for(Long seekerIdx : dto.getSeekerList()) {
-//            for(String estimatorEmail : dto.getEstimatorList()) {
-//                String estimatorPassword = UUID.randomUUID().toString();
-//                Optional<Estimator> resultEstimator = estimatorRepository.findByEstimatorEmail(estimatorEmail);
-//                Estimator estimator = null;
-//                if(resultEstimator.isEmpty()){
-//                    estimator = Estimator.builder()
-//                            .role("ROLE_ESTIMATOR")
-//                            .email(estimatorEmail)
-//                            // UUID로 저장하고, UUID를 이메일로 전송
-//                            .password(passwordEncoder.encode("qwer1234"))
-//                            .emailAuth(true)
-//                            .build();
-//                    estimatorRepository.save(estimator);
-//                } else {
-//                    estimator = resultEstimator.get();
-//                }
-//                estimatorList.add(estimator);
-//                InterviewParticipate interviewParticipate = interviewParticipateRepository.save(InterviewParticipate.builder()
-//                        .seeker(seekerRepository.findBySeekerIdx(seekerIdx).orElseThrow(() -> new BaseException(BaseResponseMessage.MEMBER_NOT_FOUND)))
-//                        .estimator(estimator)
-//                        .team(team)
-//                        .interviewSchedule(interviewSchedule)
-//                        .build());
-//                interviewParticipateRepository.save(interviewParticipate);
-//            }
-//        }
-//        return InterviewScheduleRes.builder()
-//                .idx(interviewSchedule.getIdx())
-//                .estimatorList(dto.getEstimatorList())
-//                .seekerList(dto.getSeekerList())
-//                .isOnline(interviewSchedule.getIsOnline())
-//                .interviewDate(interviewSchedule.getInterviewDate())
-//                .interviewEnd(interviewSchedule.getInterviewEnd())
-//                .interviewStart(interviewSchedule.getInterviewStart())
-//                .uuid(interviewSchedule.getUuid())
-//                .build();
-//    }
-
-    public InterviewScheduleRes create(InterviewScheduleReq dto) throws BaseException {
-        String uuid = UUID.randomUUID().toString();
-        Recruiter recruiter = recruiterRepository.findByRecruiterIdx(1L)
+    public InterviewScheduleRes create(CustomUserDetails customUserDetails, InterviewScheduleReq dto) throws BaseException {
+        String uuid = uuidCheck(dto);
+        Recruiter recruiter = recruiterRepository.findByRecruiterIdx(customUserDetails.getIdx())
                 .orElseThrow(() -> new BaseException(BaseResponseMessage.MEMBER_NOT_FOUND));
-        Announcement announcement = announcementRepository.findByAnnounceIdx(1L)
+        Announcement announcement = announcementRepository.findByAnnounceIdx(dto.getAnnouncementIdx())
                 .orElseThrow(() -> new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL));
         Team team = teamRepository.findByIdx(dto.getTeamIdx())
                 .orElseThrow(() -> new BaseException(BaseResponseMessage.TEAM_NOT_FOUND));
@@ -125,11 +63,11 @@ public class InterviewScheduleService {
                 .interviewEnd(dto.getInterviewEnd())
                 .uuid(uuid)
                 .careerBase(dto.getCareerBase())
+                .recruiter(recruiter)
                 .announcement(announcement)
+                .team(team)
                 .build();
         interviewScheduleRepository.save(interviewSchedule);
-
-        System.out.println("@@@@@@@면접관 등록 시작");
 
         List<Estimator> estimatorList = new ArrayList<>();
         List<Seeker> seekerList = new ArrayList<>();
@@ -143,7 +81,6 @@ public class InterviewScheduleService {
                     estimator = Estimator.builder()
                             .role("ROLE_ESTIMATOR")
                             .email(estimatorEmail)
-                            .name("면접관")
                             // UUID로 저장하고, UUID를 이메일로 전송
                             .password(passwordEncoder.encode("qwer1234"))
                             .emailAuth(true)
@@ -162,23 +99,9 @@ public class InterviewScheduleService {
                 interviewParticipateRepository.save(interviewParticipate);
             }
         }
-
-        System.out.println("@@@@@@@알람 등록 시작");
-        // Alarm 저장 로직
-        alarmRepository.save(Alarm.builder()
-                        .type("면접일정")
-                        .status(false)
-                        .message("귀하의 면접일정은 다음과 같습니다.")
-                        .seeker(seekerRepository.findBySeekerIdx(1L).orElseThrow(() -> new BaseException(BaseResponseMessage.MEMBER_NOT_FOUND)))
-                        .interviewSchedule(interviewSchedule)
-                        .createdAt(LocalDateTime.now())
-                        .url("iehglskjfasel-welifhwlkgjwelifj")
-                        .build());
-
         return InterviewScheduleRes.builder()
                 .idx(interviewSchedule.getIdx())
                 .estimatorList(dto.getEstimatorList())
-                .seekerList(dto.getSeekerList())
                 .isOnline(interviewSchedule.getIsOnline())
                 .interviewDate(interviewSchedule.getInterviewDate())
                 .interviewEnd(interviewSchedule.getInterviewEnd())
@@ -187,42 +110,65 @@ public class InterviewScheduleService {
                 .build();
     }
 
-//    public String uuidCheck(InterviewScheduleReq dto) {
-//        String uuid = "";
-//        List<InterviewSchedule> result = interviewScheduleRepository.findByInterviewDate(dto.getInterviewDate());
-//
-//        // 날짜가 없으면 생성
-//        if(result.isEmpty()) {
-//            uuid = UUID.randomUUID().toString();
-//
-//            return uuid;
-//        }
-//
-//        for(InterviewSchedule interviewSchedule : result) {
-//            if((interviewSchedule.getTeam().getIdx()).equals(dto.getTeamIdx())) {
-//                uuid = interviewSchedule.getUuid();
-//            }
-//        }
-//
-//        if(uuid.isEmpty()) {
-//            uuid = UUID.randomUUID().toString();
-//        }
-//
-//        return uuid;
-//    }
+    public String uuidCheck(InterviewScheduleReq dto) {
+        String uuid = "";
+        List<InterviewSchedule> result = interviewScheduleRepository.findByInterviewDate(dto.getInterviewDate());
 
-    public List<InterviewScheduleRes> readAllExp() {
-        List<InterviewSchedule> result = interviewScheduleRepository.findByCareerBase("경력");
+        // 날짜가 없으면 생성
+        if(result.isEmpty()) {
+            uuid = UUID.randomUUID().toString();
+
+            return uuid;
+        }
+
+        for(InterviewSchedule interviewSchedule : result) {
+            if((interviewSchedule.getTeam().getIdx()).equals(dto.getTeamIdx())) {
+                uuid = interviewSchedule.getUuid();
+            }
+        }
+
+        if(uuid.isEmpty()) {
+            uuid = UUID.randomUUID().toString();
+        }
+
+        return uuid;
+    }
+
+    public List<InterviewScheduleRes> readAll(String careerBase, Long idx) {
+        Optional<List<InterviewSchedule>> result;
+        if(careerBase == "전체") {
+            result = interviewScheduleRepository.findByAnnouncementIdx(idx);
+        } else {
+            result = interviewScheduleRepository.findByCareerBaseAndAnnouncementIdx(careerBase, idx);
+        }
+
+
+//        Optional<List<SeekerInfoGetRes>> seekerResult =
 
         List<InterviewScheduleRes> interviewScheduleList = new ArrayList<>();
-        for(InterviewSchedule interviewSchedule : result) {
-            interviewScheduleList.add(InterviewScheduleRes.builder()
-                    .idx(interviewSchedule.getIdx())
-                    .isOnline(interviewSchedule.getIsOnline())
-                    .interviewDate(interviewSchedule.getInterviewDate())
-                    .interviewStart(interviewSchedule.getInterviewStart())
-                    .interviewEnd(interviewSchedule.getInterviewEnd())
-                    .build());
+
+        if(!result.isEmpty()) {
+            for (InterviewSchedule interviewSchedule : result.get()) {
+                List<SeekerInfoGetRes> seekerInfoGetResList = new ArrayList<>();
+                List<InterviewParticipate> participateResult = interviewParticipateRepository.findByInterviewScheduleIdx(interviewSchedule.getIdx());
+
+                for(InterviewParticipate interviewParticipate : participateResult) {
+                    seekerInfoGetResList.add(SeekerInfoGetRes.builder()
+                            .idx(interviewParticipate.getIdx())
+                            .name(seekerRepository.findBySeekerIdx(interviewParticipate.getSeeker().getIdx()).get().getName())
+                            .email(seekerRepository.findBySeekerIdx(interviewParticipate.getSeeker().getIdx()).get().getEmail())
+                            .build());
+                }
+                interviewScheduleList.add(InterviewScheduleRes.builder()
+                        .idx(interviewSchedule.getIdx())
+                        .isOnline(interviewSchedule.getIsOnline())
+                        .interviewDate(interviewSchedule.getInterviewDate())
+                        .interviewStart(interviewSchedule.getInterviewStart())
+                        .interviewEnd(interviewSchedule.getInterviewEnd())
+                        .teamIdx(interviewSchedule.getTeam().getIdx())
+                        .seekerList(seekerInfoGetResList)
+                        .build());
+            }
         }
 
         return interviewScheduleList;
@@ -231,15 +177,15 @@ public class InterviewScheduleService {
     public ReScheduleRes createReSchedule(ReScheduleReq dto) throws BaseException {
 
         InterviewSchedule interviewSchedule = interviewScheduleRepository.findByInterviewScheduleIdx(dto.getInterviewScheduleIdx())
-                                        .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_SCHEDULE_NOT_FOUND));
+                .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_SCHEDULE_NOT_FOUND));
         Seeker seeker = seekerRepository.findBySeekerIdx(1L).orElseThrow(() -> new BaseException(BaseResponseMessage.MEMBER_NOT_FOUND));
 
         ReSchedule reSchedule = reScheduleRepository.save(ReSchedule.builder()
-                        .interviewStart(dto.getInterviewStart())
-                        .interviewEnd(dto.getInterviewEnd())
-                        .interviewSchedule(interviewSchedule)
-                        .seeker(seeker)
-                        .build());
+                .interviewStart(dto.getInterviewStart())
+                .interviewEnd(dto.getInterviewEnd())
+                .interviewSchedule(interviewSchedule)
+                .seeker(seeker)
+                .build());
 
         return ReScheduleRes.builder()
                 .idx(reSchedule.getIdx())

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -55,6 +55,7 @@ public enum BaseResponseMessage {
     INTERVIEW_SCHEDULE_NOT_FOUND(false, 1302, "해당 면접을 찾을 수 없습니다."),
     RESCHEDULE_NOT_FOUND(false, 1303, "면접 조율 내역을 찾을 수 없습니다."),
     RESCHEDULE_SEARCH_ALL_SUCCESS(true, 1304, "면접 조율 내역 조회에 성공했습니다."),
+    INTERVIEW_SCHEDULE_READ_ALL_SUCCESS(true, 1305, "면접 내역 조회에 성공했습니다."),
 
     // VIDEO_INTERVIEW 화상 면접 1400
     VIDEO_INTERVIEW_CREATE_SUCCESS(true, 1400, "화상 면접 방 생성에 성공했습니다."),
@@ -91,6 +92,7 @@ public enum BaseResponseMessage {
     ANNOUNCEMENT_REGISTER_STEP_TWO_SUCCESS(true, 3100, "지원서 폼 조립에 성공했습니다."),
     ANNOUNCEMENT_REGISTER_STEP_TWO_FAIL_NOT_FOUND(false, 3101, "공고가 저장되지 않아 찾을 수 없습니다."),
     ANNOUNCEMENT_REGISTER_STEP_TWO_FAIL(false, 3102, "지원서 폼 조립에 실패하였습니다." ),
+    ANNOUNCEMENT_READ_ALL_SUCCESS(true, 3105, "공고 전체조회에 성공했습니다."),
     ANNOUNCEMENT_SEARCH_SUCCESS(true, 3200, "공고 조회에 성공했습니다."),
     ANNOUNCEMENT_SEARCH_FAIL(false, 3201, "공고 조회에 실패했습니다."),
     ANNOUNCEMENT_SEARCH_FAIL_NOT_FOUND(false, 3202, "해당 공고를 찾을 수 없습니다."),


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #191 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
로그인한 recruiter 정보로 등록된 공고 조회 기능 개발했습니다.
해당 공고에 등록된 각각의 면접일정 조회 기능 개발했습니다.
<br>

## ✅ 주요 작업 부분
지원자 페이지에서 보는 공고 전체 조회에서 각 공고 클릭 시 필요한 상세조회.
 - recruiter 로그인한 정보 기반 공고 조회 개발
 - 공고에 등록된 각각의 면접일정 조회 개발
 - interviewschedule에 team 연관관계 추가
 - baseresponse 추가

<br>

<br>