### PR TITLE
[#157][Fix] 지원서 제출 페이지 진입 시 필요한 데이터 조회 수정

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/model/response/ResumeReadSubmitInfoRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/model/response/ResumeReadSubmitInfoRes.java
@@ -10,7 +10,8 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class ResumeReadSubmitInfoRes {
-    private List<String> codes;
+    private List<String> codes; // 지원서 맞춤 양식 코드
+    private Boolean integrated; // 통합 지원서 등록 여부 반환
     private PersonalInfoReadRes personalInfo; // 인적사항 1개
     private PreferentialEmpReadRes preferentialEmp; // 취업우대·병역 1개
     private List<EducationReadRes> educations; // 학력 n개

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/service/ResumeService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/service/ResumeService.java
@@ -492,16 +492,34 @@ public class ResumeService {
             // 공고 idx로 공고 조회
             Optional<Announcement> resultAnnouncement = announcementRepository.findByAnnounceIdx(announcementIdx);
             if(resultAnnouncement.isPresent()) {
+                ResumeReadSubmitInfoRes.ResumeReadSubmitInfoResBuilder responseBuilder = ResumeReadSubmitInfoRes.builder();
                 // 지원서 맞춤 양식 테이블 조회
                 List<CustomForm> resultCustomForms = customFormRepository.findAllByAnnouncementIdx(resultAnnouncement.get().getIdx());
                 List<String> formCodes = new ArrayList<>();
-                for(CustomForm cf : resultCustomForms) {
-                    formCodes.add(cf.getCode());
+                if(!resultCustomForms.isEmpty()) {
+                    for(CustomForm cf : resultCustomForms) {
+                        formCodes.add(cf.getCode());
+                    }
+                    responseBuilder.codes(formCodes);
+                }
+                if(formCodes.contains("resume_011")) { // 자기소개서
+                    List<CustomLetterForm> resultCustomLetterForm = customLetterFormRepository.findAllByAnnouncementIdx(announcementIdx);
+                    if(!resultCustomLetterForm.isEmpty()) {
+                        // 자기소개서 맞춤 양식 테이블 조회 (공고 idx로)
+                        List<CustomLetterFormReadRes> customLetterFormResList = new ArrayList<>();
+                        for(CustomLetterForm customLetterForm : resultCustomLetterForm) {
+                            CustomLetterFormReadRes customLetterFormRes = CustomLetterFormReadRes.builder()
+                                    .title(customLetterForm.getTitle())
+                                    .chatLimit(customLetterForm.getChatLimit())
+                                    .build();
+                            customLetterFormResList.add(customLetterFormRes);
+                        }
+                        responseBuilder.customLetterForms(customLetterFormResList);
+                    }
                 }
                 // 지원정보 테이블 조회 (통합 지원서)
                 Optional<ResumeInfo> resultResumeInfo = resumeInfoRepository.findBySeekerIdxAndIntegrated(seekerIdx, true);
                 if(resultResumeInfo.isPresent()) {
-                    ResumeReadSubmitInfoRes.ResumeReadSubmitInfoResBuilder responseBuilder = ResumeReadSubmitInfoRes.builder();
                     // 인적사항
                     Optional<PersonalInfo> resultPersonalInfo = personalInfoRepository.findByResumeInfoIdx(resultResumeInfo.get().getIdx());
                     if(resultPersonalInfo.isPresent()) {
@@ -518,217 +536,199 @@ public class ResumeService {
                                 .build();
                         responseBuilder.personalInfo(personalInfoRes);
                     }
-
-
-                    if(!resultCustomForms.isEmpty()) {
-                        responseBuilder.codes(formCodes);
-
-                        if(formCodes.contains("resume_001")) { // 학력
-                            List<Education> resultEducations = educationRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
-                            if(!resultEducations.isEmpty()) {
-                                List<EducationReadRes> educationResList = new ArrayList<>();
-                                for(Education education : resultEducations) {
-                                    EducationReadRes educationRes = EducationReadRes.builder()
-                                            .schoolDiv(education.getSchoolDiv())
-                                            .schoolName(education.getSchoolName())
-                                            .enteredAt(education.getEnteredAt())
-                                            .graduatedAt(education.getGraduatedAt())
-                                            .graduationStatus(education.getGraduationStatus())
-                                            .majorName(education.getMajorName())
-                                            .grade(education.getGrade())
-                                            .totalGrade(education.getTotalGrade())
-                                            .transfer(education.getTransfer())
-                                            .majorType(education.getMajorType())
-                                            .otherMajor(education.getOtherMajor())
-                                            .graduationWork(education.getGraduationWork())
-                                            .degree(education.getDegree())
-                                            .qualificationExam(education.getQualificationExam())
-                                            .passedAt(education.getPassedAt())
-                                            .build();
-                                    educationResList.add(educationRes);
-                                }
-                                responseBuilder.educations(educationResList);
-                            }
-                        }
-                        if(formCodes.contains("resume_002")) { // 경력
-                            List<PersonalHistory> resultPersonalHistories = personalHistoryRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
-                            if(!resultPersonalHistories.isEmpty()) {
-                                List<PersonalHistoryReadRes> personalHistoryResList = new ArrayList<>();
-                                for(PersonalHistory personalHistory : resultPersonalHistories) {
-                                    PersonalHistoryReadRes personalHistoryRes = PersonalHistoryReadRes.builder()
-                                            .companyName(personalHistory.getCompanyName())
-                                            .deptName(personalHistory.getDeptName())
-                                            .enteredAt(personalHistory.getEnteredAt())
-                                            .quitAt(personalHistory.getQuitAt())
-                                            .empStatus(personalHistory.getEmpStatus())
-                                            .position(personalHistory.getPosition())
-                                            .job(personalHistory.getJob())
-                                            .salary(personalHistory.getSalary())
-                                            .work(personalHistory.getWork())
-                                            .build();
-                                    personalHistoryResList.add(personalHistoryRes);
-                                }
-                                responseBuilder.personalHistories(personalHistoryResList);
-                            }
-                        }
-                        if(formCodes.contains("resume_003")) { // 인턴&대외활동
-                            List<InternsActivity> resultInternsActivities = internActivitiesRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
-                            if(!resultInternsActivities.isEmpty()) {
-                                List<InternsActivityReadRes> internsActivityResList = new ArrayList<>();
-                                for(InternsActivity internsActivity : resultInternsActivities) {
-                                    InternsActivityReadRes internsActivityRes = InternsActivityReadRes.builder()
-                                            .activityDiv(internsActivity.getActivityDiv())
-                                            .organization(internsActivity.getOrganization())
-                                            .startAt(internsActivity.getStartAt())
-                                            .endAt(internsActivity.getEndAt())
-                                            .contents(internsActivity.getContents())
-                                            .build();
-                                    internsActivityResList.add(internsActivityRes);
-                                }
-                                responseBuilder.internsActivities(internsActivityResList);
-                            }
-                        }
-                        if(formCodes.contains("resume_004")) { // 교육이수
-                            List<Training> resultTrainings = trainingRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
-                            if(!resultTrainings.isEmpty()) {
-                                List<TrainingReadRes> trainingResList = new ArrayList<>();
-                                for(Training training : resultTrainings) {
-                                    TrainingReadRes trainingRes = TrainingReadRes.builder()
-                                            .trainingName(training.getTrainingName())
-                                            .organization(training.getOrganization())
-                                            .startAt(training.getStartAt())
-                                            .endAt(training.getEndAt())
-                                            .contents(training.getContents())
-                                            .build();
-                                    trainingResList.add(trainingRes);
-                                }
-                                responseBuilder.trainings(trainingResList);
-                            }
-                        }
-                        if(formCodes.contains("resume_005")) { // 자격증
-                            List<Certification> resultCertifications = certificationRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
-                            if(!resultCertifications.isEmpty()) {
-                                List<CertificationReadRes> certificationResList = new ArrayList<>();
-                                for(Certification certification : resultCertifications) {
-                                    CertificationReadRes certificationRes = CertificationReadRes.builder()
-                                            .certName(certification.getCertName())
-                                            .organization(certification.getOrganization())
-                                            .takingAt(certification.getTakingAt())
-                                            .build();
-                                    certificationResList.add(certificationRes);
-                                }
-                                responseBuilder.certifications(certificationResList);
-                            }
-                        }
-                        if(formCodes.contains("resume_006")) { // 수상
-                            List<Award> resultAwards = awardRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
-                            if(!resultAwards.isEmpty()) {
-                                List<AwardReadRes> awardResList = new ArrayList<>();
-                                for(Award award : resultAwards) {
-                                    AwardReadRes awardRes = AwardReadRes.builder()
-                                            .awardName(award.getAwardName())
-                                            .contents(award.getContents())
-                                            .organization(award.getOrganization())
-                                            .year(award.getYear())
-                                            .build();
-                                    awardResList.add(awardRes);
-                                }
-                                responseBuilder.awards(awardResList);
-                            }
-                        }
-                        if(formCodes.contains("resume_007")) { // 해외경험
-                            List<StudyingAbroad> resultStudyingAbroads = studyingAboardRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
-                            if(!resultStudyingAbroads.isEmpty()) {
-                                List<StudyingAbroadReadRes> studyingAbroadResList = new ArrayList<>();
-                                for(StudyingAbroad studyingAbroad : resultStudyingAbroads) {
-                                    StudyingAbroadReadRes studyingAbroadRes = StudyingAbroadReadRes.builder()
-                                            .countryName(studyingAbroad.getCountryName())
-                                            .startAt(studyingAbroad.getStartAt())
-                                            .endAt(studyingAbroad.getEndAt())
-                                            .contents(studyingAbroad.getContents())
-                                            .build();
-                                    studyingAbroadResList.add(studyingAbroadRes);
-                                }
-                                responseBuilder.studyingAbroads(studyingAbroadResList);
-                            }
-
-                        }
-                        if(formCodes.contains("resume_008")) { // 어학
-                            List<Language> resultLanguages = languageRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
-                            if(!resultLanguages.isEmpty()) {
-                                List<LanguageReadRes> languageResList = new ArrayList<>();
-                                for(Language language : resultLanguages) {
-                                    LanguageReadRes languageRes = LanguageReadRes.builder()
-                                            .testDiv(language.getTestDiv())
-                                            .languageName(language.getLanguageName())
-                                            .conversationLevel(language.getConversationLevel())
-                                            .officialTest(language.getOfficialTest())
-                                            .score(language.getScore())
-                                            .takingAt(language.getTakingAt())
-                                            .build();
-                                    languageResList.add(languageRes);
-                                }
-                                responseBuilder.languages(languageResList);
-                            }
-                        }
-                        if(formCodes.contains("resume_009")) { // 포트폴리오
-                            List<Portfolio> resultPortfolios = portfolioRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
-                            if(!resultPortfolios.isEmpty()) {
-                                List<PortfolioReadRes> portfolioResList = new ArrayList<>();
-                                for(Portfolio portfolio : resultPortfolios) {
-                                    PortfolioReadRes portfolioRes = PortfolioReadRes.builder()
-                                            .portfolioDiv(portfolio.getPortfolioDiv())
-                                            .portfolioType(portfolio.getPortfolioType())
-                                            .portfolioUrl(portfolio.getPortfolioUrl())
-                                            .build();
-                                    portfolioResList.add(portfolioRes);
-                                }
-                                responseBuilder.portfolios(portfolioResList);
-                            }
-
-                        }
-                        if(formCodes.contains("resume_010")) { // 취업우대&병역
-                            Optional<PreferentialEmp> resultPreferentialEmp = preferentialEmpRepository.findByResumeInfoIdx(resultResumeInfo.get().getIdx());
-                            if(resultPreferentialEmp.isPresent()) {
-                                PreferentialEmp preferentialEmp = resultPreferentialEmp.get();
-                                PreferentialEmpReadRes preferentialEmpRes = PreferentialEmpReadRes.builder()
-                                        .veterans(preferentialEmp.getVeterans())
-                                        .protection(preferentialEmp.getProtection())
-                                        .subsidy(preferentialEmp.getSubsidy())
-                                        .disability(preferentialEmp.getDisability())
-                                        .disabilityDegree(preferentialEmp.getDisabilityDegree())
-                                        .military(preferentialEmp.getMilitary())
-                                        .militaryClass(preferentialEmp.getMilitaryClass())
-                                        .militaryStart(preferentialEmp.getMilitaryStart())
-                                        .militaryEnd(preferentialEmp.getMilitaryEnd())
-                                        .militaryType(preferentialEmp.getMilitaryType())
-                                        .militaryRank(preferentialEmp.getMilitaryRank())
+                    if(formCodes.contains("resume_001")) { // 학력
+                        List<Education> resultEducations = educationRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
+                        if(!resultEducations.isEmpty()) {
+                            List<EducationReadRes> educationResList = new ArrayList<>();
+                            for(Education education : resultEducations) {
+                                EducationReadRes educationRes = EducationReadRes.builder()
+                                        .schoolDiv(education.getSchoolDiv())
+                                        .schoolName(education.getSchoolName())
+                                        .enteredAt(education.getEnteredAt())
+                                        .graduatedAt(education.getGraduatedAt())
+                                        .graduationStatus(education.getGraduationStatus())
+                                        .majorName(education.getMajorName())
+                                        .grade(education.getGrade())
+                                        .totalGrade(education.getTotalGrade())
+                                        .transfer(education.getTransfer())
+                                        .majorType(education.getMajorType())
+                                        .otherMajor(education.getOtherMajor())
+                                        .graduationWork(education.getGraduationWork())
+                                        .degree(education.getDegree())
+                                        .qualificationExam(education.getQualificationExam())
+                                        .passedAt(education.getPassedAt())
                                         .build();
-                                responseBuilder.preferentialEmp(preferentialEmpRes);
+                                educationResList.add(educationRes);
                             }
-                        }
-                        if(formCodes.contains("resume_011")) { // 자기소개서
-                            List<CustomLetterForm> resultCustomLetterForm = customLetterFormRepository.findAllByAnnouncementIdx(announcementIdx);
-                            if(!resultCustomLetterForm.isEmpty()) {
-                                // 자기소개서 맞춤 양식 테이블 조회 (공고 idx로)
-                                List<CustomLetterFormReadRes> customLetterFormResList = new ArrayList<>();
-                                for(CustomLetterForm customLetterForm : resultCustomLetterForm) {
-                                    CustomLetterFormReadRes customLetterFormRes = CustomLetterFormReadRes.builder()
-                                            .title(customLetterForm.getTitle())
-                                            .chatLimit(customLetterForm.getChatLimit())
-                                            .build();
-                                    customLetterFormResList.add(customLetterFormRes);
-                                }
-                                responseBuilder.customLetterForms(customLetterFormResList);
-                            }
+                            responseBuilder.educations(educationResList);
                         }
                     }
+                    if(formCodes.contains("resume_002")) { // 경력
+                        List<PersonalHistory> resultPersonalHistories = personalHistoryRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
+                        if(!resultPersonalHistories.isEmpty()) {
+                            List<PersonalHistoryReadRes> personalHistoryResList = new ArrayList<>();
+                            for(PersonalHistory personalHistory : resultPersonalHistories) {
+                                PersonalHistoryReadRes personalHistoryRes = PersonalHistoryReadRes.builder()
+                                        .companyName(personalHistory.getCompanyName())
+                                        .deptName(personalHistory.getDeptName())
+                                        .enteredAt(personalHistory.getEnteredAt())
+                                        .quitAt(personalHistory.getQuitAt())
+                                        .empStatus(personalHistory.getEmpStatus())
+                                        .position(personalHistory.getPosition())
+                                        .job(personalHistory.getJob())
+                                        .salary(personalHistory.getSalary())
+                                        .work(personalHistory.getWork())
+                                        .build();
+                                personalHistoryResList.add(personalHistoryRes);
+                            }
+                            responseBuilder.personalHistories(personalHistoryResList);
+                        }
+                    }
+                    if(formCodes.contains("resume_003")) { // 인턴&대외활동
+                        List<InternsActivity> resultInternsActivities = internActivitiesRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
+                        if(!resultInternsActivities.isEmpty()) {
+                            List<InternsActivityReadRes> internsActivityResList = new ArrayList<>();
+                            for(InternsActivity internsActivity : resultInternsActivities) {
+                                InternsActivityReadRes internsActivityRes = InternsActivityReadRes.builder()
+                                        .activityDiv(internsActivity.getActivityDiv())
+                                        .organization(internsActivity.getOrganization())
+                                        .startAt(internsActivity.getStartAt())
+                                        .endAt(internsActivity.getEndAt())
+                                        .contents(internsActivity.getContents())
+                                        .build();
+                                internsActivityResList.add(internsActivityRes);
+                            }
+                            responseBuilder.internsActivities(internsActivityResList);
+                        }
+                    }
+                    if(formCodes.contains("resume_004")) { // 교육이수
+                        List<Training> resultTrainings = trainingRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
+                        if(!resultTrainings.isEmpty()) {
+                            List<TrainingReadRes> trainingResList = new ArrayList<>();
+                            for(Training training : resultTrainings) {
+                                TrainingReadRes trainingRes = TrainingReadRes.builder()
+                                        .trainingName(training.getTrainingName())
+                                        .organization(training.getOrganization())
+                                        .startAt(training.getStartAt())
+                                        .endAt(training.getEndAt())
+                                        .contents(training.getContents())
+                                        .build();
+                                trainingResList.add(trainingRes);
+                            }
+                            responseBuilder.trainings(trainingResList);
+                        }
+                    }
+                    if(formCodes.contains("resume_005")) { // 자격증
+                        List<Certification> resultCertifications = certificationRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
+                        if(!resultCertifications.isEmpty()) {
+                            List<CertificationReadRes> certificationResList = new ArrayList<>();
+                            for(Certification certification : resultCertifications) {
+                                CertificationReadRes certificationRes = CertificationReadRes.builder()
+                                        .certName(certification.getCertName())
+                                        .organization(certification.getOrganization())
+                                        .takingAt(certification.getTakingAt())
+                                        .build();
+                                certificationResList.add(certificationRes);
+                            }
+                            responseBuilder.certifications(certificationResList);
+                        }
+                    }
+                    if(formCodes.contains("resume_006")) { // 수상
+                        List<Award> resultAwards = awardRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
+                        if(!resultAwards.isEmpty()) {
+                            List<AwardReadRes> awardResList = new ArrayList<>();
+                            for(Award award : resultAwards) {
+                                AwardReadRes awardRes = AwardReadRes.builder()
+                                        .awardName(award.getAwardName())
+                                        .contents(award.getContents())
+                                        .organization(award.getOrganization())
+                                        .year(award.getYear())
+                                        .build();
+                                awardResList.add(awardRes);
+                            }
+                            responseBuilder.awards(awardResList);
+                        }
+                    }
+                    if(formCodes.contains("resume_007")) { // 해외경험
+                        List<StudyingAbroad> resultStudyingAbroads = studyingAboardRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
+                        if(!resultStudyingAbroads.isEmpty()) {
+                            List<StudyingAbroadReadRes> studyingAbroadResList = new ArrayList<>();
+                            for(StudyingAbroad studyingAbroad : resultStudyingAbroads) {
+                                StudyingAbroadReadRes studyingAbroadRes = StudyingAbroadReadRes.builder()
+                                        .countryName(studyingAbroad.getCountryName())
+                                        .startAt(studyingAbroad.getStartAt())
+                                        .endAt(studyingAbroad.getEndAt())
+                                        .contents(studyingAbroad.getContents())
+                                        .build();
+                                studyingAbroadResList.add(studyingAbroadRes);
+                            }
+                            responseBuilder.studyingAbroads(studyingAbroadResList);
+                        }
+
+                    }
+                    if(formCodes.contains("resume_008")) { // 어학
+                        List<Language> resultLanguages = languageRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
+                        if(!resultLanguages.isEmpty()) {
+                            List<LanguageReadRes> languageResList = new ArrayList<>();
+                            for(Language language : resultLanguages) {
+                                LanguageReadRes languageRes = LanguageReadRes.builder()
+                                        .testDiv(language.getTestDiv())
+                                        .languageName(language.getLanguageName())
+                                        .conversationLevel(language.getConversationLevel())
+                                        .officialTest(language.getOfficialTest())
+                                        .score(language.getScore())
+                                        .takingAt(language.getTakingAt())
+                                        .build();
+                                languageResList.add(languageRes);
+                            }
+                            responseBuilder.languages(languageResList);
+                        }
+                    }
+//                    if(formCodes.contains("resume_009")) { // 포트폴리오
+//                        List<Portfolio> resultPortfolios = portfolioRepository.findAllByResumeInfoIdx(resultResumeInfo.get().getIdx());
+//                        if(!resultPortfolios.isEmpty()) {
+//                            List<PortfolioReadRes> portfolioResList = new ArrayList<>();
+//                            for(Portfolio portfolio : resultPortfolios) {
+//                                PortfolioReadRes portfolioRes = PortfolioReadRes.builder()
+//                                        .portfolioDiv(portfolio.getPortfolioDiv())
+//                                        .portfolioType(portfolio.getPortfolioType())
+//                                        .portfolioUrl(portfolio.getPortfolioUrl())
+//                                        .build();
+//                                portfolioResList.add(portfolioRes);
+//                            }
+//                            responseBuilder.portfolios(portfolioResList);
+//                        }
+//                    }
+                    if(formCodes.contains("resume_010")) { // 취업우대&병역
+                        Optional<PreferentialEmp> resultPreferentialEmp = preferentialEmpRepository.findByResumeInfoIdx(resultResumeInfo.get().getIdx());
+                        if(resultPreferentialEmp.isPresent()) {
+                            PreferentialEmp preferentialEmp = resultPreferentialEmp.get();
+                            PreferentialEmpReadRes preferentialEmpRes = PreferentialEmpReadRes.builder()
+                                    .veterans(preferentialEmp.getVeterans())
+                                    .protection(preferentialEmp.getProtection())
+                                    .subsidy(preferentialEmp.getSubsidy())
+                                    .disability(preferentialEmp.getDisability())
+                                    .disabilityDegree(preferentialEmp.getDisabilityDegree())
+                                    .military(preferentialEmp.getMilitary())
+                                    .militaryClass(preferentialEmp.getMilitaryClass())
+                                    .militaryStart(preferentialEmp.getMilitaryStart())
+                                    .militaryEnd(preferentialEmp.getMilitaryEnd())
+                                    .militaryType(preferentialEmp.getMilitaryType())
+                                    .militaryRank(preferentialEmp.getMilitaryRank())
+                                    .build();
+                            responseBuilder.preferentialEmp(preferentialEmpRes);
+                        }
+                    }
+
+
                     // 응답 dto 생성
                     return responseBuilder
+                            .integrated(true)
                             .build();
-                } else {
-                    throw new BaseException(BaseResponseMessage.RESUME_READ_FAIL_INTEGRATED);
                 }
+                return responseBuilder
+                        .integrated(false)
+                        .build();
             } else {
                 throw new BaseException(BaseResponseMessage.RESUME_REGISTER_FAIL_NOT_FOUND_ANNOUNCE);
             }

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -79,7 +79,7 @@ public enum BaseResponseMessage {
     RESUME_REGISTER_FAIL_NOT_FOUND_FILE(false, 2005, "파일을 찾을 수 없습니다."),
     RESUME_REGISTER_FAIL_NOT_FOUND_CUSTOM_FORM(false, 2006, "지원서 맞춤 양식을 조회할 수 없습니다."),
     RESUME_REGISTER_FAIL_RESUME_DUPLICATE(false, 2007, "이미 지원서가 제출된 공고입니다."),
-    RESUME_READ_SUCCESS(false, 2100, "지원서 조회에 성공하였습니다." ),
+    RESUME_READ_SUCCESS(true, 2100, "지원서 조회에 성공하였습니다." ),
     RESUME_READ_FAIL(false, 2101, "지원서 조회에 실패하였습니다." ),
     RESUME_READ_FAIL_INTEGRATED(false, 2102, "통합 지원서를 등록하지 않았습니다. 먼저 등록해주세요." ),
     RESUME_READ_FAIL_RESUME(false, 2103, "해당 공고에 지원한 기록이 존재하지 않습니다." ),


### PR DESCRIPTION
## 💭 연관된 이슈
closed: #157 
<!-- #1 -->
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
지원자가 공고 상세에서 지원서 등록 클릭 시 공고를 등록한 채용 담당자가 선택한 지원서 항목과 자기소개서 맞춤 양식을 조회하고, 지원자가 등록한 통합 지원서가 있을 때만 조회하게 수정

<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
<br>

## ✅ 주요구현 기능
응답 dto에 통합 지원서 등록 여부를 추가

<!-- 
- 좋아요 추가 및 제거
- 좋아요 개수 확인
-->
<br>

<br>

