### PR TITLE
[#197][Feat] 면접관 지원자 화상 면접 평가 생성 개발

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/entity/Seeker.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/entity/Seeker.java
@@ -73,7 +73,4 @@ public class Seeker {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "seeker")
     private List<ReSchedule> reScheduleList;
 
-    @OneToMany(mappedBy = "seeker", fetch = FetchType.LAZY)
-    private List<InterviewEvaluate> interviewEvaluateList = new ArrayList<>();
-
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/controller/InterviewEvaluateController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/controller/InterviewEvaluateController.java
@@ -1,10 +1,8 @@
 package com.sabujaks.irs.domain.interview_evaluate.controller;
 
+import com.sabujaks.irs.domain.interview_evaluate.model.request.InterviewEvaluateCreateReq;
 import com.sabujaks.irs.domain.interview_evaluate.model.request.InterviewEvaluateFormCreateReq;
-import com.sabujaks.irs.domain.interview_evaluate.model.response.InterviewEvaluateFormCreateRes;
-import com.sabujaks.irs.domain.interview_evaluate.model.response.InterviewEvaluateFormReadRes;
-import com.sabujaks.irs.domain.interview_evaluate.model.response.InterviewEvaluateReadAllResumeInfo;
-import com.sabujaks.irs.domain.interview_evaluate.model.response.InterviewEvaluateReadResumeInfoRes;
+import com.sabujaks.irs.domain.interview_evaluate.model.response.*;
 import com.sabujaks.irs.domain.interview_evaluate.service.InterviewEvaluateService;
 import com.sabujaks.irs.global.common.exception.BaseException;
 import com.sabujaks.irs.global.common.responses.BaseResponse;
@@ -49,5 +47,13 @@ public class InterviewEvaluateController {
         @RequestParam String interviewScheduleUUID) throws BaseException {
         InterviewEvaluateReadAllResumeInfo response = interviewEvaluateService.readAllResumeInfo(customUserDetails, announcementUUID, interviewScheduleUUID);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_RESUME_SUCCESS, response));
+    }
+
+    @PostMapping("/create-evaluate")
+    public ResponseEntity<BaseResponse<InterviewEvaluateCreateRes>> createEvaluate(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @RequestBody InterviewEvaluateCreateReq dto) throws BaseException {
+        InterviewEvaluateCreateRes response = interviewEvaluateService.createEvaluate(customUserDetails, dto);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.INTERVIEW_EVALUATE_CREATE_SUCCESS, response));
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/entity/InterviewEvaluate.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/entity/InterviewEvaluate.java
@@ -1,6 +1,8 @@
 package com.sabujaks.irs.domain.interview_evaluate.model.entity;
 
+import com.sabujaks.irs.domain.auth.model.entity.Estimator;
 import com.sabujaks.irs.domain.auth.model.entity.Seeker;
+import com.sabujaks.irs.domain.interview_schedule.model.entity.InterviewParticipate;
 import com.sabujaks.irs.domain.interview_schedule.model.entity.InterviewSchedule;
 import jakarta.persistence.*;
 import lombok.*;
@@ -15,16 +17,13 @@ public class InterviewEvaluate {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
-    private String status;
-    private Long totalCount;
+    private Boolean status;
+    private Integer totalScore;
+    private String comments;
 
     @ManyToOne
-    @JoinColumn(name="seeker_idx")
-    private Seeker seeker;
-
-    @ManyToOne
-    @JoinColumn(name = "interviewSchedule_idx")
-    private InterviewSchedule interviewSchedule;
+    @JoinColumn(name = "interviewParticipate_idx")
+    private InterviewParticipate interviewParticipate;
 
     @ManyToOne
     @JoinColumn(name = "interviewEvaluateForm_idx")

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/entity/InterviewEvaluateResult.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/entity/InterviewEvaluateResult.java
@@ -15,16 +15,16 @@ public class InterviewEvaluateResult {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
-    private String r1;
-    private String r2;
-    private String r3;
-    private String r4;
-    private String r5;
-    private String r6;
-    private String r7;
-    private String r8;
-    private String r9;
-    private String r10;
+    private Integer r1;
+    private Integer r2;
+    private Integer r3;
+    private Integer r4;
+    private Integer r5;
+    private Integer r6;
+    private Integer r7;
+    private Integer r8;
+    private Integer r9;
+    private Integer r10;
 
     @OneToMany(mappedBy = "interviewEvaluateResult")
     private List<InterviewEvaluate> interviewEvaluateList;

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/request/InterviewEvaluateCreateReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/request/InterviewEvaluateCreateReq.java
@@ -1,0 +1,20 @@
+package com.sabujaks.irs.domain.interview_evaluate.model.request;
+
+import lombok.*;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewEvaluateCreateReq {
+    private String userEmail;
+    private Map<Integer, Integer> scores; // 질문 번호와 점수의 맵
+    private Integer totalScore;
+    private Boolean status;
+    private String comments;
+    private String announcementUUID;
+    private String videoInterviewUUID;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateCreateRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateCreateRes.java
@@ -1,0 +1,12 @@
+package com.sabujaks.irs.domain.interview_evaluate.model.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewEvaluateCreateRes {
+    private Long idx;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/repository/InterviewEvaluateFormRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/repository/InterviewEvaluateFormRepository.java
@@ -13,4 +13,6 @@ import java.util.Optional;
 public interface InterviewEvaluateFormRepository extends JpaRepository<InterviewEvaluateForm, Long> {
     @Query("SELECT ief FROM InterviewEvaluateForm ief WHERE ief.announcement.uuid = :announcementUUID")
     Optional<InterviewEvaluateForm> findByAnnouncementUUID(String announcementUUID);
+    @Query("SELECT ief FROM InterviewEvaluateForm ief WHERE ief.announcement.idx = :announceIdx")
+    Optional<InterviewEvaluateForm> findByAnnounceIdx(Long announceIdx);
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/repository/InterviewEvaluateRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/repository/InterviewEvaluateRepository.java
@@ -10,7 +10,8 @@ import java.util.Optional;
 
 @EnableJpaRepositories
 public interface InterviewEvaluateRepository extends JpaRepository<InterviewEvaluate, Long> {
-    @Query("SELECT ief FROM InterviewEvaluateForm ief WHERE ief.announcement.idx = :announceIdx")
-    Optional<InterviewEvaluateForm> findByAnnounceIdx(Long announceIdx);
+    @Query("SELECT ie FROM InterviewEvaluate ie WHERE ie.interviewParticipate.idx = :interviewParticipateIdx")
+    Optional<InterviewEvaluate> findByInterviewParticipateIdx(Long interviewParticipateIdx);
+
 }
 

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/InterviewParticipate.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/InterviewParticipate.java
@@ -2,11 +2,14 @@ package com.sabujaks.irs.domain.interview_schedule.model.entity;
 
 import com.sabujaks.irs.domain.auth.model.entity.Estimator;
 import com.sabujaks.irs.domain.auth.model.entity.Seeker;
+import com.sabujaks.irs.domain.interview_evaluate.model.entity.InterviewEvaluate;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -17,6 +20,9 @@ public class InterviewParticipate {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
+
+    @OneToMany(mappedBy = "interviewParticipate")
+    private List<InterviewEvaluate> interviewEvaluateList;
 
     @ManyToOne
     @JoinColumn(name="interviewSchedule_idx")

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/InterviewSchedule.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/InterviewSchedule.java
@@ -53,9 +53,6 @@ public class InterviewSchedule {
 
     @OneToMany(mappedBy = "interviewSchedule")
     private List<ReSchedule> reScheduleList;
-  
-    @OneToMany(mappedBy = "interviewSchedule", fetch = FetchType.LAZY)
-    private List<InterviewEvaluate> interviewEvaluateList;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="team_idx")

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/repository/InterviewParticipateRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/repository/InterviewParticipateRepository.java
@@ -14,5 +14,11 @@ public interface InterviewParticipateRepository extends JpaRepository<InterviewP
     @Query("SELECT ip FROM InterviewParticipate ip WHERE ip.estimator.idx = :estimatorIdx AND ip.interviewSchedule.uuid = :interviewScheduleUUID")
     Optional<List<InterviewParticipate>> findAllByEstimatorIdxAndInterviewScheduleUUID(Long estimatorIdx, String interviewScheduleUUID);
 
+    @Query("SELECT ip FROM InterviewParticipate ip WHERE " +
+            "ip.seeker.email = :seekerEmail AND " +
+            "ip.estimator.idx = :estimatorIdx AND " +
+            "ip.interviewSchedule.uuid = :interviewScheduleUUID")
+    Optional<InterviewParticipate> findBySeekerEmailAndEstimatorIdxAndInterviewScheduleUUID(String seekerEmail, Long estimatorIdx, String interviewScheduleUUID);
+
     List<InterviewParticipate> findByInterviewScheduleIdx(Long interviewScheduleIdx);
 }

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -119,8 +119,11 @@ public enum BaseResponseMessage {
     INTERVIEW_EVALUATE_SEARCH_FORM_FAIL_INVALID_ACCESS(false, 6102, "해당 공고의 인터뷰 평가표에 접근할 수 없습니다."),
     // 인터뷰 지원서 조회 6200
     INTERVIEW_EVALUATE_SEARCH_RESUME_SUCCESS(true, 6200, "지원자들의 지원서 정보를 불러오는데 성공했습니다." ),
-    INTERVIEW_EVALUATE_SEARCH_RESUME_FAIL_NOT_FOUND(false, 6201, "지원자들의 지원서 정보를 불러오는데 실패했습니다.");
-
+    INTERVIEW_EVALUATE_SEARCH_RESUME_FAIL_NOT_FOUND(false, 6201, "지원자들의 지원서 정보를 불러오는데 실패했습니다."),
+    // 인터뷰 평가 생성 6300
+    INTERVIEW_EVALUATE_CREATE_SUCCESS(true, 6300, "해당 지원자의 인터뷰 평가를 생성하는데 성공했습니다."),
+    INTERVIEW_EVALUATE_CREATE_FAIL_INVALID_FORM(false, 6302, "해당 공고의 인터뷰 평가 항목이 잘못되었습니다."),
+    INTERVIEW_EVALUATE_CREATE_FAIL_NOT_FOUND_SCHEDULE(false, 6301, "해당 면접관과 지원자의 인터뷰 스케줄 정보가 없습니다.");
 
     private Boolean success;
     private Integer code;


### PR DESCRIPTION
## 💭 연관된 이슈
closed #197
<br>
## 📌 구현 목표
면접관 화상 면접 평가 제출 기능을 개발
<br>
## ✅ 주요구현 기능
1. findBySeekerEmailAndEstimatorIdxAndInterviewScheduleUUID 메서드를 사용해 인터뷰 참여자 찾기
2. findByAnnouncementUUID를 통해 인터뷰 평가 폼을 가져오고, 없으면 예외
3. findByInterviewParticipateIdx로 해당 인터뷰 참여자에 대한 기존 평가가 있는지 확인
4. 기존 평가가 있을 경우, 새로운 평가 데이터를 DTO에서 가져와 InterviewEvaluateResult, nterviewEvaluate 업데이트
5. 기존 평가가 없을 경우, 새로운 InterviewEvaluateResult와 InterviewEvaluate 객체를 생성해 저장

