### PR TITLE
[#46][Feat] 채용 담당자 서류 합불 개발 완료

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/controller/ResumeController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/controller/ResumeController.java
@@ -2,6 +2,7 @@ package com.sabujaks.irs.domain.resume.controller;
 
 import com.sabujaks.irs.domain.resume.model.request.ResumeCreateReq;
 import com.sabujaks.irs.domain.resume.model.request.ResumeSubmitReq;
+import com.sabujaks.irs.domain.resume.model.request.ResumeUpdateDocPassedReq;
 import com.sabujaks.irs.domain.resume.model.response.*;
 import com.sabujaks.irs.domain.resume.service.ResumeService;
 import com.sabujaks.irs.global.common.exception.BaseException;
@@ -118,5 +119,16 @@ public class ResumeController {
 
         ResumeReadRes response = resumeService.read(resumeIdx);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.RESUME_READ_SUCCESS, response));
+    }
+
+    // (채용담당자) 서류 결과 업데이트
+    @PatchMapping("/update/docPassed/{resumeIdx}")
+    public ResponseEntity<BaseResponse<ResumeUpdateDocPassedRes>> updateDocPassed(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @PathVariable Long resumeIdx,
+        @RequestBody ResumeUpdateDocPassedReq dto) throws BaseException {
+
+        ResumeUpdateDocPassedRes response = resumeService.updateDocPassed(customUserDetails, resumeIdx, dto);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.RESUME_UPDATE_SUCCESS_DOC_PASSED, response));
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/model/entity/Resume.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/model/entity/Resume.java
@@ -2,6 +2,8 @@ package com.sabujaks.irs.domain.resume.model.entity;
 
 import com.sabujaks.irs.domain.announcement.model.entity.Announcement;
 import com.sabujaks.irs.domain.auth.model.entity.Seeker;
+import com.sabujaks.irs.global.common.exception.BaseException;
+import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,6 +31,8 @@ public class Resume {
     @CreationTimestamp
     private LocalDateTime resumedAt;
 
+    private Boolean docPassed;
+
     // 지원정보 테이블과 n:1
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "resume_info_idx")
@@ -43,4 +47,13 @@ public class Resume {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seeker_idx")
     private Seeker seeker;
+
+    public Boolean updateDocPassed(Boolean docPassed) {
+        if (this.docPassed == null) {
+            this.docPassed = docPassed;
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/model/request/ResumeUpdateDocPassedReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/model/request/ResumeUpdateDocPassedReq.java
@@ -1,0 +1,12 @@
+package com.sabujaks.irs.domain.resume.model.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResumeUpdateDocPassedReq {
+    private Boolean docPassed;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/model/response/ResumeReadRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/model/response/ResumeReadRes.java
@@ -14,6 +14,7 @@ public class ResumeReadRes {
     private List<String> codes;
     private String resumeTitle;
     private LocalDateTime resumedAt;
+    private Boolean docPassed;
     private PersonalInfoReadRes personalInfo; // 인적사항 1개
     private PreferentialEmpReadRes preferentialEmp; // 취업우대·병역 1개
     private List<EducationReadRes> educations; // 학력 n개

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/model/response/ResumeUpdateDocPassedRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/model/response/ResumeUpdateDocPassedRes.java
@@ -1,0 +1,13 @@
+package com.sabujaks.irs.domain.resume.model.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResumeUpdateDocPassedRes {
+    private Long resumeIdx;
+    private Boolean docPassed;
+}

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -87,6 +87,11 @@ public enum BaseResponseMessage {
     RESUME_READ_FAIL_INTEGRATED(false, 2102, "통합 지원서를 등록하지 않았습니다. 먼저 등록해주세요." ),
     RESUME_READ_FAIL_RESUME(false, 2103, "해당 공고에 지원한 기록이 존재하지 않습니다." ),
     RESUME_READ_FAIL_RESUME_INFO(false, 2104, "해당 공고에 지원한 지원서가 존재하지 않습니다." ),
+    RESUME_UPDATE_SUCCESS(true, 2200, "지원서 수정에 성공하였습니다." ),
+    RESUME_UPDATE_SUCCESS_DOC_PASSED(true, 2201, "서류 합격/불합격 처리 완료되었습니다." ),
+    RESUME_UPDATE_FAIL_DOC_PASSED(false, 2202, "서류 합격/불합격 처리에 실패하였습니다." ),
+    RESUME_UPDATE_FAIL_DOC_PASSED_ALREADY(false, 2202, "이미 처리되었습니다." ),
+
 
     // ANNOUNCEMENT 3000~3999
     ANNOUNCEMENT_REGISTER_STEP_ONE_SUCCESS(true, 3000, "공고 등록에 성공했습니다."),


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed: #46 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
채용 담당자가 공고에 지원한 지원자의 지원서를 상세 조회하고 페이지에서 서류 합격 또는 불합격 버튼을 클릭해서 서류 결과 처리
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
<br>

## ✅ 주요구현 기능
인턴·대외활동, 해외경험, 어학 테이블 생성 및 테이블에 데이터 저장
<!-- 
- 좋아요 추가 및 제거
- 좋아요 개수 확인
-->
공고 지원서 엔티티에 서류 결과 컬럼추가 (docPassed)
서류 결과 컬럼의 기본값은 null이고, 채용 담당자가 지원서 상세 조회 페이지에서 합격(1) 또는 불합격(2) 버튼을 눌렀을 때 공고 지원서의 서류 결과 값 업데이트
한번 선택하면 서류 결과 바꿀 수 없다.
<br>

<br>

