### PR TITLE
[#56][Feat] 채용담당자 화상 면접 평가 목록 조회 개발 완료

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/controller/InterviewEvaluateController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/controller/InterviewEvaluateController.java
@@ -25,35 +25,43 @@ public class InterviewEvaluateController {
 
     @PostMapping("/create-form")
     public ResponseEntity<BaseResponse> createForm(
-        @AuthenticationPrincipal CustomUserDetails customUserDetails,
-        @RequestBody InterviewEvaluateFormCreateReq dto) throws BaseException {
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody InterviewEvaluateFormCreateReq dto) throws BaseException {
         InterviewEvaluateFormCreateRes response = interviewEvaluateService.createForm(customUserDetails, dto);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.INTERVIEW_EVALUATE_CREATE_FORM_SUCCESS, response));
     }
 
     @GetMapping("/search-form")
     public ResponseEntity<BaseResponse> searchForm(
-        @AuthenticationPrincipal CustomUserDetails customUserDetails,
-        @RequestParam String announcementUUID,
-        @RequestParam(required = false) String interviewScheduleUUID) throws BaseException {
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam String announcementUUID,
+            @RequestParam(required = false) String interviewScheduleUUID) throws BaseException {
         InterviewEvaluateFormReadRes response = interviewEvaluateService.searchForm(customUserDetails, announcementUUID, interviewScheduleUUID);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_FORM_SUCCESS, response));
     }
 
     @GetMapping("/read-all/resume-info")
     public ResponseEntity<BaseResponse<InterviewEvaluateReadAllResumeInfo>> readAllResumeInfo(
-        @AuthenticationPrincipal CustomUserDetails customUserDetails,
-        @RequestParam String announcementUUID,
-        @RequestParam String interviewScheduleUUID) throws BaseException {
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam String announcementUUID,
+            @RequestParam String interviewScheduleUUID) throws BaseException {
         InterviewEvaluateReadAllResumeInfo response = interviewEvaluateService.readAllResumeInfo(customUserDetails, announcementUUID, interviewScheduleUUID);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_RESUME_SUCCESS, response));
     }
 
     @PostMapping("/create-evaluate")
     public ResponseEntity<BaseResponse<InterviewEvaluateCreateRes>> createEvaluate(
-        @AuthenticationPrincipal CustomUserDetails customUserDetails,
-        @RequestBody InterviewEvaluateCreateReq dto) throws BaseException {
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody InterviewEvaluateCreateReq dto) throws BaseException {
         InterviewEvaluateCreateRes response = interviewEvaluateService.createEvaluate(customUserDetails, dto);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.INTERVIEW_EVALUATE_CREATE_SUCCESS, response));
+    }
+
+    @GetMapping("/read-all/evaluate")
+    public ResponseEntity<BaseResponse<InterviewEvaluateReadAllRes>> readAllEvaluate (
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam Long announceIdx)throws BaseException {
+        InterviewEvaluateReadAllRes response = interviewEvaluateService.readAllEvaluate(customUserDetails, announceIdx);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.INTERVIEW_EVALUATE_READ_ALL_SUCCESS, response));
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateReadAllRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateReadAllRes.java
@@ -1,0 +1,14 @@
+package com.sabujaks.irs.domain.interview_evaluate.model.response;
+
+import lombok.*;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewEvaluateReadAllRes {
+    private Map<Long, InterviewEvaluateReadRes> interviewEvaluateReadResumeInfoResMap;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateReadRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateReadRes.java
@@ -1,0 +1,15 @@
+package com.sabujaks.irs.domain.interview_evaluate.model.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewEvaluateReadRes {
+    private String seekerName;
+    private Integer totalScore;
+    private String comments;
+    private String estimatorEmail;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/service/InterviewEvaluateService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/service/InterviewEvaluateService.java
@@ -18,6 +18,7 @@ import com.sabujaks.irs.domain.interview_evaluate.repository.InterviewEvaluateFo
 import com.sabujaks.irs.domain.interview_evaluate.repository.InterviewEvaluateRepository;
 import com.sabujaks.irs.domain.interview_evaluate.repository.InterviewEvaluateResultRepository;
 import com.sabujaks.irs.domain.interview_schedule.model.entity.InterviewParticipate;
+import com.sabujaks.irs.domain.interview_schedule.model.entity.InterviewSchedule;
 import com.sabujaks.irs.domain.interview_schedule.repository.InterviewParticipateRepository;
 import com.sabujaks.irs.domain.interview_schedule.repository.InterviewScheduleRepository;
 import com.sabujaks.irs.domain.resume.model.entity.*;
@@ -39,9 +40,6 @@ public class InterviewEvaluateService {
     private final InterviewEvaluateFormRepository interviewEvaluateFormRepository;
     private final InterviewParticipateRepository interviewParticipateRepository;
     private final AnnouncementRepository announcementRepository;
-    private final SeekerRepository seekerRepository;
-    private final CustomFormRepository customFormRepository;
-    private final ResumeInfoRepository resumeInfoRepository;
     private final ResumeRepository resumeRepository;
     private final CustomResumeInfoRepository customResumeInfoRepository;
     private final PersonalInfoRepository personalInfoRepository;
@@ -57,10 +55,11 @@ public class InterviewEvaluateService {
     private final PortfolioRepository portfolioRepository;
     private final CustomLetterFormRepository customLetterFormRepository;
     private final InterviewEvaluateResultRepository interviewEvaluateResultRepository;
+    private final InterviewScheduleRepository interviewScheduleRepository;
 
     public InterviewEvaluateFormCreateRes createForm (CustomUserDetails customUserDetails, InterviewEvaluateFormCreateReq dto) throws BaseException {
         Announcement announcement = announcementRepository.findByAnnounceIdx(dto.getAnnounceIdx())
-        .orElseThrow(() -> new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL));
+                .orElseThrow(() -> new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL));
         if(!Objects.equals(announcement.getRecruiter().getEmail(), customUserDetails.getEmail())){
             throw new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_CREATE_FORM_FAIL_INVALID_REQUEST);
         }
@@ -105,7 +104,7 @@ public class InterviewEvaluateService {
     public InterviewEvaluateFormReadRes searchForm(CustomUserDetails customUserDetails, String announcementUUID, String interviewScheduleUUID) throws  BaseException {
         if(Objects.equals(customUserDetails.getRole(), "ROLE_RECRUITER")){
             InterviewEvaluateForm interviewEvaluateForm = interviewEvaluateFormRepository.findByAnnouncementUUID(announcementUUID)
-            .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_FORM_FAIL_IS_NOT_EXIST));
+                    .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_FORM_FAIL_IS_NOT_EXIST));
             if(!Objects.equals(interviewEvaluateForm.getAnnouncement().getRecruiter().getEmail(), customUserDetails.getEmail())){
                 throw new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_FORM_FAIL_INVALID_ACCESS);
             };
@@ -126,7 +125,7 @@ public class InterviewEvaluateService {
                 throw new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_FORM_FAIL_INVALID_ACCESS);
             }
             InterviewEvaluateForm interviewEvaluateForm = interviewEvaluateFormRepository.findByAnnouncementUUID(announcementUUID)
-            .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_FORM_FAIL_IS_NOT_EXIST));
+                    .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_FORM_FAIL_IS_NOT_EXIST));
             return InterviewEvaluateFormReadRes.builder()
                     .q1(interviewEvaluateForm.getQ1())
                     .q2(interviewEvaluateForm.getQ2())
@@ -147,15 +146,15 @@ public class InterviewEvaluateService {
     @Transactional
     public InterviewEvaluateReadAllResumeInfo readAllResumeInfo(CustomUserDetails customUserDetails,String announcementUUID, String interviewScheduleUUID) throws BaseException{
         List<InterviewParticipate> interviewParticipateList = interviewParticipateRepository
-        .findAllByEstimatorIdxAndInterviewScheduleUUID(customUserDetails.getIdx(), interviewScheduleUUID)
-        .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_FORM_FAIL_INVALID_ACCESS));
+                .findAllByEstimatorIdxAndInterviewScheduleUUID(customUserDetails.getIdx(), interviewScheduleUUID)
+                .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_FORM_FAIL_INVALID_ACCESS));
         Map<Long, InterviewEvaluateReadResumeInfoRes> interviewEvaluateReadResumeInfoResMap = new HashMap();
         for(InterviewParticipate interviewParticipate:interviewParticipateList){
             Seeker seeker = interviewParticipate.getSeeker();
             Announcement announcement = announcementRepository.findByAnnouncementUUID(announcementUUID)
-            .orElseThrow(() -> new BaseException(BaseResponseMessage.RESUME_REGISTER_FAIL_NOT_FOUND_ANNOUNCE));
+                    .orElseThrow(() -> new BaseException(BaseResponseMessage.RESUME_REGISTER_FAIL_NOT_FOUND_ANNOUNCE));
             Resume resume = resumeRepository.findByAnnouncementIdxAndSeekerIdx(announcement.getIdx(), seeker.getIdx())
-            .orElseThrow(()-> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_RESUME_FAIL_NOT_FOUND));
+                    .orElseThrow(()-> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_SEARCH_RESUME_FAIL_NOT_FOUND));
             List<CustomResumeInfo> customResumeInfoList = customResumeInfoRepository.findAllByResumeInfoIdx(resume.getResumeInfo().getIdx());
             InterviewEvaluateReadResumeInfoRes.InterviewEvaluateReadResumeInfoResBuilder responseBuilder = InterviewEvaluateReadResumeInfoRes.builder();
             Optional<PersonalInfo> resultPersonalInfo = personalInfoRepository.findByResumeInfoIdx(resume.getResumeInfo().getIdx());
@@ -384,10 +383,10 @@ public class InterviewEvaluateService {
     @Transactional
     public InterviewEvaluateCreateRes createEvaluate(CustomUserDetails customUserDetails, InterviewEvaluateCreateReq dto) throws BaseException{
         InterviewParticipate interviewParticipate = interviewParticipateRepository
-        .findBySeekerEmailAndEstimatorIdxAndInterviewScheduleUUID(dto.getUserEmail(), customUserDetails.getIdx(), dto.getVideoInterviewUUID())
-        .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_CREATE_FAIL_NOT_FOUND_SCHEDULE));
+                .findBySeekerEmailAndEstimatorIdxAndInterviewScheduleUUID(dto.getUserEmail(), customUserDetails.getIdx(), dto.getVideoInterviewUUID())
+                .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_CREATE_FAIL_NOT_FOUND_SCHEDULE));
         InterviewEvaluateForm interviewEvaluateForm = interviewEvaluateFormRepository.findByAnnouncementUUID(dto.getAnnouncementUUID())
-        .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_CREATE_FAIL_INVALID_FORM));
+                .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_CREATE_FAIL_INVALID_FORM));
         Optional<InterviewEvaluate> result = interviewEvaluateRepository.findByInterviewParticipateIdx(interviewParticipate.getIdx());
         if(result.isPresent()){
             InterviewEvaluate interviewEvaluate = result.get();
@@ -445,5 +444,34 @@ public class InterviewEvaluateService {
                     .idx(interviewEvaluate.getIdx())
                     .build();
         }
+    }
+
+    public InterviewEvaluateReadAllRes readAllEvaluate(CustomUserDetails customUserDetails, Long announceIdx) throws BaseException {
+        Announcement announcement = announcementRepository.findByAnnounceIdx(announceIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL_NOT_FOUND));
+        if (!Objects.equals(announcement.getRecruiter().getEmail(), customUserDetails.getEmail())) {
+            throw new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL_INVALID_REQUEST);
+        }
+        Map<Long, InterviewEvaluateReadRes> interviewEvaluateReadAllResMap = new HashMap<>();
+        List<InterviewSchedule> interviewScheduleList = interviewScheduleRepository.findByAnnouncementIdx(announceIdx)
+                .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_SCHEDULE_NOT_FOUND));
+        for(InterviewSchedule interviewSchedule : interviewScheduleList){
+            List<InterviewParticipate> interviewParticipateList = interviewParticipateRepository.findByInterviewScheduleIdx(interviewSchedule.getIdx())
+                    .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_PARTICIPATE_NOT_FOUND));
+            for(InterviewParticipate interviewParticipate : interviewParticipateList){
+                InterviewEvaluate interviewEvaluate = interviewEvaluateRepository.findByInterviewParticipateIdx(interviewParticipate.getIdx())
+                        .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_READ_ALL_FAIL));
+                InterviewEvaluateReadRes interviewEvaluateReadRes = InterviewEvaluateReadRes.builder()
+                        .estimatorEmail(interviewParticipate.getEstimator().getEmail())
+                        .seekerName(interviewParticipate.getSeeker().getName())
+                        .totalScore(interviewEvaluate.getTotalScore())
+                        .comments(interviewEvaluate.getComments())
+                        .build();
+                interviewEvaluateReadAllResMap.put(interviewParticipate.getSeeker().getIdx(), interviewEvaluateReadRes);
+            }
+        }
+        return InterviewEvaluateReadAllRes.builder()
+                .interviewEvaluateReadResumeInfoResMap(interviewEvaluateReadAllResMap)
+                .build();
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -105,6 +105,7 @@ public enum BaseResponseMessage {
     ANNOUNCEMENT_SEARCH_SUCCESS(true, 3300, "공고 조회에 성공했습니다."),
     ANNOUNCEMENT_SEARCH_FAIL(false, 3301, "공고 조회에 실패했습니다."),
     ANNOUNCEMENT_SEARCH_FAIL_NOT_FOUND(false, 3302, "해당 공고를 찾을 수 없습니다."),
+    ANNOUNCEMENT_SEARCH_FAIL_INVALID_REQUEST(false, 3303, "해당 공고의 채용 담당자가 아닙니다."),
     // COMPANY 기업정보 관련 4000~4999
     COMPANY_INFO_SUCCESS(true, 4000, "기업 정보 등록에 성공했습니다."),
     COMPANY_INFO_SUCCESS_REGISTER(true, 4001, "기업 복리후생 조회에 성공했습니다."),
@@ -132,7 +133,10 @@ public enum BaseResponseMessage {
     // 인터뷰 평가 생성 6300
     INTERVIEW_EVALUATE_CREATE_SUCCESS(true, 6300, "해당 지원자의 인터뷰 평가를 생성하는데 성공했습니다."),
     INTERVIEW_EVALUATE_CREATE_FAIL_INVALID_FORM(false, 6302, "해당 공고의 인터뷰 평가 항목이 잘못되었습니다."),
-    INTERVIEW_EVALUATE_CREATE_FAIL_NOT_FOUND_SCHEDULE(false, 6301, "해당 면접관과 지원자의 인터뷰 스케줄 정보가 없습니다.");
+    INTERVIEW_EVALUATE_CREATE_FAIL_NOT_FOUND_SCHEDULE(false, 6301, "해당 면접관과 지원자의 인터뷰 스케줄 정보가 없습니다."),
+    // 인터뷰 평가 조회 6400
+    INTERVIEW_EVALUATE_READ_ALL_SUCCESS(true, 6400, "지원자들의 면접 평가 결과를 불러왔습니다."),
+    INTERVIEW_EVALUATE_READ_ALL_FAIL(true, 6401, "지원자들의 면접 평가 결과를 불러오는데 실패했습니다.");
 
     private Boolean success;
     private Integer code;


### PR DESCRIPTION
## 💭 연관된 이슈
closed #56 
<br>
## 📌 구현 목표
채용담당자 화상 면접 평가 목록 조회 기능 개발
<br>
## ✅ 주요구현 기능
1.  announceIdx에 해당하는 공고(Announcement)를 announcementRepository에서 찾아옴, 없으면 예외
2. 조회된 공고의 채용담당자 이메일과 현재 사용자(customUserDetails)의 이메일을 비교해 일치하지 않으면 예외
3. 공고 idx로 interviewScheduleRepository에서 면접 일정을 조회, 조회된 면접 일정에 해당하는 면접 참여자 리스트 가져옴
4. 각 면접 참여자에 대해 interviewEvaluateRepository에서 평가 데이터를 조회 및 반환