### PR TITLE
[#18][Feat] 채용담당자 기업 관련 기능, 기준 코드 조회 기능 개발

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/service/AnnouncementService.java
@@ -16,7 +16,7 @@ import com.sabujaks.irs.domain.auth.repository.RecruiterRepository;
 import com.sabujaks.irs.domain.company.model.entity.Company;
 import com.sabujaks.irs.domain.company.repository.CompanyBenefitsRepository;
 import com.sabujaks.irs.domain.company.repository.CompanyRepository;
-import com.sabujaks.irs.domain.data_init.entity.BaseInfo;
+import com.sabujaks.irs.domain.data_init.model.entity.BaseInfo;
 import com.sabujaks.irs.domain.data_init.repository.BaseInfoRepository;
 import com.sabujaks.irs.domain.resume.repository.ResumeRepository;
 import com.sabujaks.irs.global.common.exception.BaseException;

--- a/backend/src/main/java/com/sabujaks/irs/domain/company/model/entity/Company.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/company/model/entity/Company.java
@@ -24,7 +24,6 @@ public class Company {
     private String crn; // 사업자 등록 번호
     private String openedAt; // 개업일자
 
-    @Column(length = 20)
     private String industry; // 산업
 
     @Column(length = 30)

--- a/backend/src/main/java/com/sabujaks/irs/domain/company/model/response/CompanyReadRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/company/model/response/CompanyReadRes.java
@@ -1,0 +1,36 @@
+package com.sabujaks.irs.domain.company.model.response;
+
+import com.sabujaks.irs.domain.announcement.model.response.BenefitCategory;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CompanyReadRes {
+    private String saved; // 등록됐는지 안됐는지 확인용
+    private Long companyIdx;
+
+    // 기업인증테이블에서 가져오는 값들
+    private String ceoName; // 대표자 명
+    private String crn; // 사업자 등록 번호
+    private String openedAt; // 개업일자
+
+    private String industry; // 산업
+    private String name; // 기업 명
+    private String type; // 기업구분
+    private String companyInfo; // 기업소개
+    private String capital; // 자본금
+    private String totalEmp; // 사원수
+    private String establishDate; // 설립일
+    private String sales; // 매출액
+    private String business; // 주요사업
+    private String homeUrl; // 홈페이지url
+    private String address; // 기업주소
+    private List<String> imgUrlList; // 회사 이미지 리스트
+    private List<BenefitCategory> companyBenefitsList; // 회사 복리후생 리스트
+
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/company/repository/CompanyImgRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/company/repository/CompanyImgRepository.java
@@ -3,5 +3,8 @@ package com.sabujaks.irs.domain.company.repository;
 import com.sabujaks.irs.domain.company.model.entity.CompanyImg;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CompanyImgRepository extends JpaRepository<CompanyImg, Long> {
+    List<CompanyImg> findByCompanyIdx(Long idx);
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/company/service/CompanyService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/company/service/CompanyService.java
@@ -1,5 +1,7 @@
 package com.sabujaks.irs.domain.company.service;
 
+import com.sabujaks.irs.domain.announcement.model.response.CompanyInfoReadRes;
+import com.sabujaks.irs.domain.announcement.service.AnnouncementService;
 import com.sabujaks.irs.domain.auth.model.entity.CompanyVerify;
 import com.sabujaks.irs.domain.auth.model.entity.Recruiter;
 import com.sabujaks.irs.domain.auth.repository.CompanyVerifyRepository;
@@ -9,16 +11,19 @@ import com.sabujaks.irs.domain.company.model.entity.CompanyBenefits;
 import com.sabujaks.irs.domain.company.model.entity.CompanyImg;
 import com.sabujaks.irs.domain.company.model.request.CompanyCreateReq;
 import com.sabujaks.irs.domain.company.model.response.CompanyCreateRes;
+import com.sabujaks.irs.domain.company.model.response.CompanyReadRes;
 import com.sabujaks.irs.domain.company.repository.CompanyBenefitsRepository;
 import com.sabujaks.irs.domain.company.repository.CompanyImgRepository;
 import com.sabujaks.irs.domain.company.repository.CompanyRepository;
 import com.sabujaks.irs.global.common.exception.BaseException;
 import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
+import com.sabujaks.irs.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,6 +36,85 @@ public class CompanyService {
     private final CompanyImgRepository companyImgRepository;
     private final CompanyBenefitsRepository companyBenefitsRepository;
     private final CompanyVerifyRepository companyVerifyRepository;
+    private final AnnouncementService announcementService;
+
+    /*******채용담당자 기업정보 조회 (마이페이지 입장 시)***********/
+    public CompanyReadRes readCompany(CustomUserDetails customUserDetails) throws BaseException {
+        Long recruiterIdx = customUserDetails.getIdx();
+
+        // 채용담당자 확인
+        Optional<Recruiter> resultRecruiter = recruiterRepository.findByRecruiterIdx(recruiterIdx);
+        if(resultRecruiter.isPresent()) {
+            // 필수 기업인증 정보 불러오기
+            Optional<CompanyVerify> resultCompanyVerify = companyVerifyRepository.findByRecruiterEmail(resultRecruiter.get().getEmail());
+
+            // 기업을 등록했었는지 확인
+            Optional<Company> resultCompany = companyRepository.findByRecruiterIdx(recruiterIdx);
+            if(resultCompany.isPresent()) {
+                // 만약 기업등록이 이미 됐다면, 있는 정보 보내주기
+                Company company = resultCompany.get();
+
+                // companyIdx를 기준으로 이미지 URL 리스트 조회
+                List<CompanyImg> companyImages = companyImgRepository.findByCompanyIdx(company.getIdx());
+                List<String> imgUrlList = new ArrayList<>();
+
+                for (CompanyImg companyImg : companyImages) {
+                    imgUrlList.add(companyImg.getUrl()); // 각 이미지 객체에서 URL을 추출하여 리스트에 추가
+                }
+
+                // 기업 복리후생 리스트 조회
+                CompanyInfoReadRes companyInfoReadRes = announcementService.readCompanyInfo(resultRecruiter.get().getEmail());
+
+                // 등록된 기업 정보를 반환
+                return CompanyReadRes.builder()
+                        .saved("Y")  // 이미 기업이 등록되어 있다는 표시
+                        .companyIdx(company.getIdx())
+                        .ceoName(resultCompanyVerify.get().getCeoName())  // 기업이 없어도 불러오는 필수 정보
+                        .crn(resultCompanyVerify.get().getCrn())          // 사업자 등록 번호
+                        .openedAt(resultCompanyVerify.get().getOpenedAt()) // 개업일자
+                        .industry(company.getIndustry())
+                        .name(company.getName())
+                        .type(company.getType())
+                        .companyInfo(company.getCompanyInfo())
+                        .capital(company.getCapital())
+                        .totalEmp(company.getTotalEmp())
+                        .establishDate(company.getEstablishDate())
+                        .sales(company.getSales())
+                        .business(company.getBusiness())
+                        .homeUrl(company.getUrl())
+                        .address(company.getAddress())
+                        .imgUrlList(imgUrlList)
+                        .companyBenefitsList(companyInfoReadRes.getBenefitsDataList())
+                        .build();
+
+            } else {
+                // 등록된 기업이 없다면 세가지 정보만 보내주기
+                return CompanyReadRes.builder()
+                        .saved("N")  // 기업 정보가 없음을 표시
+                        .ceoName(resultCompanyVerify.get().getCeoName())  // 기업이 없어도 불러오는 필수 정보
+                        .crn(resultCompanyVerify.get().getCrn())          // 사업자 등록 번호
+                        .openedAt(resultCompanyVerify.get().getOpenedAt()) // 개업일자
+//                        .industry("")  // 나머지 정보는 빈 값 또는 null로 설정
+//                        .name("")
+//                        .type("")
+//                        .companyInfo("")
+//                        .capital("")
+//                        .totalEmp("")
+//                        .establishDate("")
+//                        .sales("")
+//                        .business("")
+//                        .homeUrl("")
+//                        .address("")
+                        .imgUrlList(new ArrayList<>())  // 빈 리스트 반환
+                        .companyBenefitsList(new ArrayList<>())  // 빈 리스트 반환
+                        .build();
+            }
+        } else {
+            // 채용담당자 유저에서 찾을 수 없을 때
+            throw new BaseException(BaseResponseMessage.COMPANY_INFO_FAIL_NOT_RECRUITER);
+        }
+    }
+
 
     /*******채용담당자 기업정보 등록***********/
     public CompanyCreateRes createCompany(
@@ -40,7 +124,6 @@ public class CompanyService {
         // 채용담당자 확인
         Optional<Recruiter> resultRecruiter = recruiterRepository.findByRecruiterIdx(recruiterIdx);
         if(resultRecruiter.isPresent()) {
-
 
 
             // 기업 인증 테이블에서 채용담당자 이메일로 기업에 대한 필요한 3가지 조회
@@ -91,11 +174,16 @@ public class CompanyService {
 
 
     /*******채용담당자 기업 이미지 등록***********/
-    public void saveCompanyImages(List<String> fileUrlList) {
+    public void saveCompanyImages(List<String> fileUrlList, Long companyIdx) {
+//        Optional<Company> resultCompany = companyRepository.findById(companyIdx);
+        Company company = Company.builder()
+                .idx(companyIdx)
+                .build();
         if (fileUrlList != null && !fileUrlList.isEmpty()) {
             for (String fileUrl : fileUrlList) {
                 // 각 URL에 대해 CompanyImg 객체 생성
                 CompanyImg companyImg = CompanyImg.builder()
+                        .company(company)
                         .url(fileUrl)
                         .createdAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))) // 현재 시간 저장
                         .updatedAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))) // 현재(수정) 시간 저장

--- a/backend/src/main/java/com/sabujaks/irs/domain/data_init/DataInit.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/data_init/DataInit.java
@@ -1,12 +1,10 @@
 package com.sabujaks.irs.domain.data_init;
 
-import com.sabujaks.irs.domain.data_init.entity.BaseInfo;
+import com.sabujaks.irs.domain.data_init.model.entity.BaseInfo;
 import com.sabujaks.irs.domain.data_init.repository.BaseInfoRepository;
 import com.sabujaks.irs.domain.interview_schedule.model.entity.Team;
 import com.sabujaks.irs.domain.interview_schedule.repository.TeamRepository;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 //@Component

--- a/backend/src/main/java/com/sabujaks/irs/domain/data_init/controller/BaseInfoController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/data_init/controller/BaseInfoController.java
@@ -1,0 +1,30 @@
+package com.sabujaks.irs.domain.data_init.controller;
+
+
+import com.sabujaks.irs.domain.data_init.model.response.CategoryRes;
+import com.sabujaks.irs.domain.data_init.service.BaseInfoService;
+import com.sabujaks.irs.global.common.exception.BaseException;
+import com.sabujaks.irs.global.common.responses.BaseResponse;
+import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/base-info")
+@RequiredArgsConstructor
+public class BaseInfoController {
+    private final BaseInfoService baseInfoService;
+
+    // 기준정보에서 필요한 카테고리 대, 소 전체 조회 (카테고리 셀렉에 사용 가능)
+    @GetMapping("/read/category")
+    public ResponseEntity<BaseResponse<CategoryRes>> getCategory(String keyword) throws BaseException {
+
+        List<CategoryRes> response = baseInfoService.getCategory(keyword);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.BASE_INFO_BENEFIT_CATEGORY_SEARCH_SUCCESS, response));
+    }
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/data_init/model/entity/BaseInfo.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/data_init/model/entity/BaseInfo.java
@@ -1,4 +1,4 @@
-package com.sabujaks.irs.domain.data_init.entity;
+package com.sabujaks.irs.domain.data_init.model.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/backend/src/main/java/com/sabujaks/irs/domain/data_init/model/response/CategoryRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/data_init/model/response/CategoryRes.java
@@ -1,0 +1,16 @@
+package com.sabujaks.irs.domain.data_init.model.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryRes {
+    private String code; // 대분류 코드
+    private String description; // 대분류 설명
+    private List<SubcategoryRes> subcategories; // 소분류 리스트
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/data_init/model/response/SubcategoryRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/data_init/model/response/SubcategoryRes.java
@@ -1,0 +1,13 @@
+package com.sabujaks.irs.domain.data_init.model.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SubcategoryRes {
+    private String code; // 소분류 코드
+    private String description; // 소분류 설명
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/data_init/repository/BaseInfoRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/data_init/repository/BaseInfoRepository.java
@@ -1,13 +1,12 @@
 package com.sabujaks.irs.domain.data_init.repository;
 
-import com.sabujaks.irs.domain.data_init.entity.BaseInfo;
+import com.sabujaks.irs.domain.data_init.model.entity.BaseInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.PatternSyntaxException;
 
 @Repository
@@ -19,17 +18,13 @@ public interface BaseInfoRepository extends JpaRepository<BaseInfo, Long> {
 
     List<BaseInfo> findByCodeIn(List<String> companyBenefitsCodes);
 
-    PatternSyntaxException findByParentCode(String parentCode);
+    @Query("SELECT b FROM BaseInfo b WHERE b.code LIKE %:inCode% AND b.parentCode IS NULL")
+    List<BaseInfo> findAllByCodeContainingAndParentCodeIsNull(@Param("inCode") String inCode);
 
-    // 특정 그룹의 기준 코드 목록 찾기
-    List<BaseInfo> findByGroupName(String groupName);
-
-    // 특정 그룹명과 parent_code로 기준 코드 찾기
-    List<BaseInfo> findByGroupNameAndParentCode(String groupName, String parentCode);
+    @Query("SELECT b FROM BaseInfo b where b.parentCode = :code")
+    List<BaseInfo> findAllByParentCode(@Param("code") String code);
 
     // 코드로 엔티티 찾기
     BaseInfo findByCode(String code);
 
-    // parent_code가 NULL인 기준 코드 (대분류 항목) 찾기
-    List<BaseInfo> findByGroupNameAndParentCodeIsNull(String groupName);
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/data_init/service/BaseInfoService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/data_init/service/BaseInfoService.java
@@ -1,0 +1,44 @@
+package com.sabujaks.irs.domain.data_init.service;
+
+import com.sabujaks.irs.domain.data_init.model.entity.BaseInfo;
+import com.sabujaks.irs.domain.data_init.model.response.CategoryRes;
+import com.sabujaks.irs.domain.data_init.model.response.SubcategoryRes;
+import com.sabujaks.irs.domain.data_init.repository.BaseInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BaseInfoService {
+    private final BaseInfoRepository baseInfoRepository;
+
+    public List<CategoryRes> getCategory(String keyword) {
+        // 대분류 데이터 조회
+        // 부모코드가 null이고 조회를 원하는 카테고리명이 코드안에 있을 때
+        List<BaseInfo> resultBaseInfoList = baseInfoRepository.findAllByCodeContainingAndParentCodeIsNull(keyword);
+        // 대분류 리스트
+        List<CategoryRes> categoryResList = new ArrayList<>();
+
+        for(BaseInfo category : resultBaseInfoList) {
+            // 대분류의 소분류 데이터 조회
+            // 대분류들의 코드를 소분류의 부모코드로 사용
+            List<BaseInfo> resultSubBaseInfoList = baseInfoRepository.findAllByParentCode(category.getCode());
+            // 소분류 리스트
+            List<SubcategoryRes> subcategoryResList = new ArrayList<>();
+
+            // 소분류 데이터를 DTO로 변환
+            for (BaseInfo subcategory : resultSubBaseInfoList) {
+                subcategoryResList.add(new SubcategoryRes(subcategory.getCode(), subcategory.getDescription()));
+            }
+
+            // 대분류 데이터를 DTO로 변환
+            categoryResList.add(new CategoryRes(category.getCode(), category.getDescription(), subcategoryResList));
+
+        }
+
+        return categoryResList;
+    }
+}

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -111,7 +111,7 @@ public enum BaseResponseMessage {
     ANNOUNCEMENT_SEARCH_FAIL_INVALID_REQUEST(false, 3303, "해당 공고의 채용 담당자가 아닙니다."),
     // COMPANY 기업정보 관련 4000~4999
     COMPANY_INFO_SUCCESS(true, 4000, "기업 정보 등록에 성공했습니다."),
-    COMPANY_INFO_SUCCESS_REGISTER(true, 4001, "기업 복리후생 조회에 성공했습니다."),
+    COMPANY_INFO_SUCCESS_REGISTER(true, 4001, "기업 필수정보 조회에 성공했습니다."),
     COMPANY_INFO_FAIL_NOT_RECRUITER(false, 4002, "채용담당자 유저가 아닙니다."),
     COMPANY_INFO_FAIL(false, 4003, "기업 정보 등록에 실패했습니다."),
     COMPANY_INFO_FAIL_NOT_REGISTER(false, 4004, "기업 정보를 등록하지 않았습니다. 먼저 등록해 주세요."),
@@ -139,7 +139,11 @@ public enum BaseResponseMessage {
     INTERVIEW_EVALUATE_CREATE_FAIL_NOT_FOUND_SCHEDULE(false, 6301, "해당 면접관과 지원자의 인터뷰 스케줄 정보가 없습니다."),
     // 인터뷰 평가 조회 6400
     INTERVIEW_EVALUATE_READ_ALL_SUCCESS(true, 6400, "지원자들의 면접 평가 결과를 불러왔습니다."),
-    INTERVIEW_EVALUATE_READ_ALL_FAIL(true, 6401, "지원자들의 면접 평가 결과를 불러오는데 실패했습니다.");
+    INTERVIEW_EVALUATE_READ_ALL_FAIL(true, 6401, "지원자들의 면접 평가 결과를 불러오는데 실패했습니다."),
+
+    // BASE_INFO 기준정보 관련 7000~7999
+    BASE_INFO_BENEFIT_CATEGORY_SEARCH_SUCCESS(true, 7000, "기준정보 중 복리후생 카테고리 조회에 성공했습니다.");
+
 
     private Boolean success;
     private Integer code;


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #18
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
채용담당자 기업 정보 조회 기능 개발 및 관련 코드 수정
<br>

## ✅ 주요 작업 부분
[기업 등록 조회] 기능 개발 수정
	백엔드
	기업 정보 조회 -> 조회 메소드 추가, 이미 등록한 기업이 있다면 모든 정보 넘겨줌
					등록한 기업이 없다면 필수 정보인 기업인증정보만 넘겨줌 
	기업 정보 등록 -> 파일 등록에 썼던 메소드 multipleUpload로 변경, 기업idx 매개변수 추가
        기준 정보 컨트롤러, 서비스 추가 ->
	기준 정보(BaseInfo) 테이블에서 카테고리별 코드 데이터 조회하여 대분류, 소분류 리스트 출력하는 메소드 추가

<br>

