### PR TITLE
[#79][Feat] 채용담당자 지원서 관리 페이지 개발 완료

### DIFF
--- a/frontend/src/pages/recruiter/resume/ResumeDetailPage.vue
+++ b/frontend/src/pages/recruiter/resume/ResumeDetailPage.vue
@@ -604,6 +604,7 @@ body {
     width: 940px;
     margin: 0 auto;
     padding-bottom: 75px;
+    padding-top: 150px;
     text-align: left;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;

--- a/frontend/src/pages/recruiter/resume/ResumeMainPage.vue
+++ b/frontend/src/pages/recruiter/resume/ResumeMainPage.vue
@@ -13,23 +13,25 @@
                   <th>신입/경력</th>
                   <th>지원자수</th>
                 </tr>
-                <tr class="announce" onclick="location.href='./seeker_list.html';">
-                  <td>1</td>
-                  <td>2024.09.24 - 2024.10.24</td>
-                  <td>백엔드 엔지니어 신입공채</td>
-                  <td>신입</td>
-                  <td>24</td>
-                </tr>
+                <tr
+                    v-for="(announcement, index) in announcementStore.announcements"
+                    :key="index"
+                    @click="handleRowClick(announcement)"
+                    style="cursor: pointer"
+                >
+                <td>{{ index + 1 }}</td>
+                <td>{{ formatDate(announcement.announcementStart) }} - {{ formatDate(announcement.announcementEnd) }}</td>
+                <td>{{ announcement.announcementTitle }}</td>
+                <td>{{ announcement.careerBase }}</td>
+                <td>{{ announcement.seekerNum }}</td>
+              </tr>
                 </tbody>
             </table>
-            <div class="button-container">
-                <button class="register-button">등록</button>
-            </div>
-            <div id="size-buttons">
+            <!-- <div id="size-buttons">
                 <button>1</button>
                 <button>2</button>
                 <button>3</button>
-            </div>
+            </div> -->
         </div>
     </div>
 </template>
@@ -37,6 +39,29 @@
 <script setup>
 import MainHeaderComponent from "@/components/recruiter/MainHeaderComponent.vue";
 import MainSideBarComponent from "@/components/recruiter/MainSideBarComponent.vue";
+import { UseAnnouncementStore } from '@/stores/UseAnnouncementStore';
+import { useRouter } from 'vue-router';
+import { onMounted } from 'vue';
+
+const announcementStore = UseAnnouncementStore();
+const router = useRouter();
+
+const formatDate = (dateString) => {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = (`0${date.getMonth() + 1}`).slice(-2); // 두 자리수로 유지
+  const day = (`0${date.getDate()}`).slice(-2);
+  return `${year}.${month}.${day}`;
+};
+
+// 컴포넌트가 로드될 때 데이터를 가져옴
+onMounted(() => {
+  announcementStore.fetchAnnouncements();
+});
+
+const handleRowClick = (announcement) => {
+    router.push(`/recruiter/resume/list/${announcement.announcementIdx}`);
+};
 </script>
 
 <style>
@@ -48,7 +73,6 @@ import MainSideBarComponent from "@/components/recruiter/MainSideBarComponent.vu
 #content {
   flex: 1;
   margin-left: 200px; /* 사이드바 너비만큼 왼쪽 여백 추가 */
-  padding: 150px 0;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;

--- a/frontend/src/stores/UseResumeStore.js
+++ b/frontend/src/stores/UseResumeStore.js
@@ -485,7 +485,8 @@ export const UseResumeStore = defineStore('resume', {
 
 
             } catch (error) {
-                alert(error.response.data.message);
+                console.log(error.response.data.message);
+                alert('공고별 지원서 조회에 실패하였습니다.');
             }
         },
         async updateDocPassed(resumeIdx, docPassedValue) {


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
Fixes: #79 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
채용담당자가 등록한 공고 목록을 조회하고, 공고를 선택하면 해당 공고에 지원한 지원자 목록 조회 페이지로 이동
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
<br>

## ✅ 주요구현 기능
채용담당자 idx로 조회
조회 정보
공고 idx
공고시작
공고마감
공고제목
신입/경력
지원자 수
<br>

<br>

