### PR TITLE
[#241][Feat] 채용담당자 화상 면접 평가 목록 조회 페이지 개발

### DIFF
--- a/frontend/src/components/recruiter/InterviewEvaluateFormMain.vue
+++ b/frontend/src/components/recruiter/InterviewEvaluateFormMain.vue
@@ -67,8 +67,10 @@
 <script setup>
 import {defineProps, defineEmits, computed, ref} from 'vue';
 import { UseInterviewEvaluateStore } from "@/stores/UseInterviewEvaluateStore";
+import { useToast } from 'vue-toastification';
 const interviewEvaluateStore = UseInterviewEvaluateStore();
 const isModalVisible = ref(false); // 모달 표시 여부를 관리하는 상태
+const toast = useToast();
 const announceIdx = ref()
 const q1 = ref('')
 const q2 = ref('')
@@ -143,7 +145,10 @@ const handleCreateForm = async() => {
         q9: q9.value,
         q10: q10.value,
     }
-    await interviewEvaluateStore.createForm(requestBody);
+    const response = await interviewEvaluateStore.createForm(requestBody);
+    if(response.success) {
+      toast.success("면접 평가표 등록에 성공했습니다.")
+    }
 }
 
 const formatDate = (datetime) => {

--- a/frontend/src/components/recruiter/InterviewEvaluateResultMain.vue
+++ b/frontend/src/components/recruiter/InterviewEvaluateResultMain.vue
@@ -1,0 +1,223 @@
+<template>
+    <div id="content">
+      <!-- props.title을 직접 사용합니다 -->
+      <h1>면접 평가 조회</h1>
+      <table class="review-table">
+        <tbody>
+        <tr>
+          <th>번호</th>
+          <th>공고기간</th>
+          <th>공고명</th>
+          <th>조회</th>
+        </tr>
+        <!--      <tr @click="handleRowClick('경력')">-->
+        <tr v-for="(announcement, index) in props.announcements" :key="announcement.idx">
+          <td>{{ startNumberForPage - index }}</td>
+          <td>{{ formatDate(announcement.announcementStart) }} - {{ formatDate(announcement.announcementEnd) }}</td>
+          <td>{{ announcement.title }}</td>
+          <td><button @click="handleSearchButton(announcement.idx)" class="searchbtn">조회</button></td>       
+        </tr>
+        </tbody>
+      </table>
+  
+      <div id="size-buttons">
+        <button v-for="page in totalPages" :key="page" @click="handlePageClick(page)">{{ page }}</button>
+      </div>
+    </div>
+  
+  
+  </template>
+  <script setup>
+  import {defineProps, defineEmits, computed, ref} from 'vue';
+  import { useRouter } from 'vue-router';
+  const router = useRouter();
+  const props = defineProps({
+    title: {
+      type: String,
+      required: true
+    },
+    careerBase: {
+      type: String,
+      required: false
+    },
+    announcements: {
+      type: Array,
+      required: false,
+      default: () => [] // 기본값 설정
+    },
+    totalAnnouncements: {
+      type: Number,
+      required: true
+    }
+  });
+  
+  const emit = defineEmits(['interviewScheduleList']);
+  
+  const handleSearchButton = (announcementIdx) => {
+    router.push(`/recruiter/interview-evaluate/result/${announcementIdx}`)
+  }
+  
+  const postsPerPage = 10;
+  const totalPages = computed(() => {
+    return props.totalAnnouncements ? Math.ceil(props.totalAnnouncements / postsPerPage) : 0;
+  });
+  
+  // 페이지 버튼 클릭 시 호출되는 메서드
+  const currentPage = ref(1); // 현재 페이지
+  
+  const handlePageClick = (pageNumber) => {
+    currentPage.value = pageNumber; // 페이지 번호 업데이트
+    emit('loadAnnouncementList', pageNumber);
+  };
+  
+  const startNumberForPage = computed(() => {
+    return props.totalAnnouncements - (currentPage.value - 1) * postsPerPage;
+  });
+  
+  const formatDate = (datetime) => {
+    const date = new Date(datetime);
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+  </script>
+  
+  <style scoped>
+  table {
+      width: 100%;
+      border: 1px solid #ddd;
+      border-collapse: collapse;
+      margin-bottom: 40px;
+      display: table;
+      box-sizing: border-box;
+      text-indent: initial;
+      unicode-bidi: isolate;
+      border-spacing: 2px;
+  }
+  
+  tbody {
+      display: table-row-group;
+      vertical-align: middle;
+      unicode-bidi: isolate;
+      border-color: inherit;
+  }
+  
+  .review-table th:nth-child(1) { /* 첫 번째 열 (번호) */
+    width: 10%; /* 비율 조정 */
+  }
+  
+  .review-table th:nth-child(2) { /* 두 번째 열 (신입/경력) */
+    width: 40%; /* 비율 조정 */
+  }
+  
+  .review-table th:nth-child(3) { /* 두 번째 열 (신입/경력) */
+    width: 40%; /* 비율 조정 */
+  }
+  
+  .review-table th:nth-child(4) { /* 두 번째 열 (신입/경력) */
+    width: 10%; /* 비율 조정 */
+  }
+  tr {
+      display: table-row;
+      vertical-align: inherit;
+      unicode-bidi: isolate;
+      border-color: inherit;
+  }
+  
+  td {
+      border: 1px solid #ddd;
+      padding: 25px;
+      text-align: center;
+  }
+  
+  th {
+      background-color: #f1f1f1;
+      padding: 25px;
+      text-align: center;
+      border: 1px solid #ddd;
+      display: table-cell;
+      vertical-align: inherit;
+      font-weight: bold;
+      text-align: -internal-center;
+      unicode-bidi: isolate;
+  }
+  
+  .modal-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 9;
+  }
+  
+  .modal-container {
+    background-color: white;
+    padding: 20px;
+    border-radius: 8px;
+    width: 80%;
+    height: 80%;
+    overflow-y: scroll;
+  }
+  
+  .modal-container h2 {
+    margin: 0 0 20px;
+  }
+  
+  .modal-container label {
+    display: block;
+    margin: 15px 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+  }
+  
+  .modal-container input {
+    width: calc(100% - 40px);
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+  
+  .modal-closebtn {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+  }
+  
+  .moadl-submitbtn {
+      width: 100%;
+      margin-top: 20px;
+      padding: 10px;
+      background-color: #232b16;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+  }
+  .searchbtn {
+      width: fit-content;
+      background-color: #2A3845;
+      border: 1px solid #ddd;
+      border-radius: 10px;
+      padding: 10px;
+      font-size: 0.8rem;
+      font-weight: bold;
+      color: white;
+      cursor: pointer;
+      height: 100%;
+      transition: background-color 0.3s;
+      display: inline-block;
+      text-decoration: none;
+  }
+  
+  .createbtn:hover {
+      background-color: #B4C7D0;
+  }
+  </style>
+  

--- a/frontend/src/components/recruiter/MainSideBarComponent.vue
+++ b/frontend/src/components/recruiter/MainSideBarComponent.vue
@@ -37,6 +37,9 @@ const goAndReload = (path) => {
         </span>
       </li>
       <ul v-if="isInterviewMenuOpen" class="submenu">
+        <li @click="goAndReload('/recruiter/interview-evaluate/form')">
+          면접 평가표
+      </li>
         <li @click="goAndReload('/recruiter/interview-schedule/new')">
           신입
         </li>
@@ -46,10 +49,11 @@ const goAndReload = (path) => {
         <li @click="goAndReload('/recruiter/interview-schedule/reschedule')">
           일정조율
         </li>
-      </ul>
-      <li @click="goAndReload('/recruiter/interview-evaluate')">
-          면접 평가표
+        <li @click="goAndReload('/recruiter/interview-evaluate/result')">
+          면접 평가
       </li>
+      </ul>
+
       <li @click="goAndReload('/recruiter/mypage')">
         마이페이지
       </li>

--- a/frontend/src/pages/recruiter/interview-evaluate/InterveiwEvaluateResultDetailPage.vue
+++ b/frontend/src/pages/recruiter/interview-evaluate/InterveiwEvaluateResultDetailPage.vue
@@ -1,0 +1,74 @@
+<template>
+    <div>
+      <MainHeaderComponent></MainHeaderComponent>
+      <div class="wrapper">
+        <MainSideBarComponent></MainSideBarComponent>
+        <div class="container">
+          <h1>면접 평가 조회</h1>
+          <table class="review-table">
+            <tbody>
+              <tr>
+                <th>번호</th>
+                <th>지원자 이름</th>
+                <th>총점</th>
+                <th>코멘트</th>
+                <th>평가자 이메일</th>
+              </tr>
+              <!-- Object.entries를 사용하여 key와 value로 나누어 v-for 적용 -->
+              <tr v-for="([key, result], index) in Object.entries(interviewEvaluateResult)" :key="key">
+                <td>{{ index + 1 }}</td>
+                <td>{{ result.seekerName || '정보 없음' }}</td>
+                <td>{{ result.totalScore }}</td>
+                <td>{{ result.comments }}</td>
+                <td>{{ result.estimatorEmail }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </template>
+  
+  <script setup>
+  import MainSideBarComponent from "@/components/recruiter/MainSideBarComponent.vue";
+  import { onMounted, ref } from "vue";
+  import MainHeaderComponent from "../../../components/recruiter/MainHeaderComponent.vue";
+  import { UseInterviewEvaluateStore } from "@/stores/UseInterviewEvaluateStore";
+  import { useRoute } from "vue-router";
+  import { useToast } from "vue-toastification";
+  
+  const interviewEvaluateStore = UseInterviewEvaluateStore();
+  const interviewEvaluateResult = ref({});
+  const route = useRoute();
+  const toast = useToast();
+  
+  onMounted(async () => {
+      const response = await interviewEvaluateStore.readAllEvaluate(route.params.announcementIdx);
+      if (response.success) {
+          interviewEvaluateResult.value = response.result.interviewEvaluateReadResumeInfoResMap;
+          console.log(interviewEvaluateResult.value);
+          toast.success("지원자들의 면접 평가 결과를 불러왔습니다.");
+      } else {
+          toast.error("평가 데이터를 불러오는 데 실패했습니다.");
+      }
+  });
+  </script>
+  
+  <style>
+  .wrapper {
+      width: 80%;
+      margin: 0 auto;
+  }
+    
+  .container {
+      width: 80%;
+      flex: 1;
+      margin: 0 auto;
+      margin-left: 200px;
+      padding: 150px 0;
+      display: flex;
+      flex-direction: column;
+      box-sizing: border-box;
+  }
+  </style>
+  

--- a/frontend/src/pages/recruiter/interview-evaluate/InterviewEvaluateFormPage.vue
+++ b/frontend/src/pages/recruiter/interview-evaluate/InterviewEvaluateFormPage.vue
@@ -4,53 +4,44 @@
     <div class="wrapper">
       <MainSideBarComponent></MainSideBarComponent>
       <div class="container">
-        <AnnouncementList
+        <InterviewEvaluateFormMain
         v-if="isInterviewScheduleMain"
         @loadAnnouncementList="loadAnnouncementList"
         :title="careerBase"
         :announcements="announcements"
         :totalAnnouncements="totalAnnouncements">
-        </AnnouncementList>
+        </InterviewEvaluateFormMain>
 
       </div>
     </div>
   </div>
-</template>
-  
-  <script setup>
+</template> 
+<script setup>
 import MainSideBarComponent from "@/components/recruiter/MainSideBarComponent.vue";
 import { onMounted, ref } from "vue";
 import MainHeaderComponent from "../../../components/recruiter/MainHeaderComponent.vue";
-import AnnouncementList from "@/components/recruiter/InterviewEvaluateFormMain.vue";
+import InterviewEvaluateFormMain from "@/components/recruiter/InterviewEvaluateFormMain.vue";
 import { UseInterviewScheduleStore } from '@/stores/UseInterviewScheduleStore';
 
 
-const interviewScheduleStore = UseInterviewScheduleStore(); // Store 인스턴스
+const interviewScheduleStore = UseInterviewScheduleStore();
 
 const totalAnnouncements = ref(0);
 const announcements = ref([]);
-
 const careerBase = ref('전체');
 const pageNum = ref(1);
 const isInterviewScheduleMain = ref(true);
 
-
-
 onMounted(async () => {
   announcements.value = await interviewScheduleStore.readAllAnnouncement(careerBase.value, pageNum.value);
   totalAnnouncements.value = await interviewScheduleStore.getTotalAnnouncement(careerBase.value);
-
-  console.log(totalAnnouncements.value);
-  console.log(announcements);
 })
+
 const loadAnnouncementList = async (btnNum) => {
   announcements.value = await interviewScheduleStore.readAllAnnouncement(careerBase.value, btnNum);
 }
-
-
 </script>
-  
-  <style>
+<style>
 .wrapper {
   width: 80%;
   margin: 0 auto;

--- a/frontend/src/pages/recruiter/interview-evaluate/InterviewEvaluateResultPage.vue
+++ b/frontend/src/pages/recruiter/interview-evaluate/InterviewEvaluateResultPage.vue
@@ -1,0 +1,97 @@
+<template>
+    <div>
+      <MainHeaderComponent></MainHeaderComponent>
+      <div class="wrapper">
+        <MainSideBarComponent></MainSideBarComponent>
+        <div class="container">
+          <div id="content">
+      <!-- props.title을 직접 사용합니다 -->
+      <h1>면접 평가 조회</h1>
+      <table class="review-table">
+        <tbody>
+        <tr>
+          <th>번호</th>
+          <th>공고기간</th>
+          <th>공고명</th>
+          <th>조회</th>
+        </tr>
+        <!--      <tr @click="handleRowClick('경력')">-->
+        <tr v-for="(announcement, index) in announcements" :key="announcement.idx">
+          <td>{{ startNumberForPage - index }}</td>
+          <td>{{ formatDate(announcement.announcementStart) }} - {{ formatDate(announcement.announcementEnd) }}</td>
+          <td>{{ announcement.title }}</td>
+          <td><button @click="handleSearchButton(announcement.idx)" class="searchbtn">조회</button></td>       
+        </tr>
+        </tbody>
+      </table>
+  
+      <div id="size-buttons">
+        <button v-for="page in totalPages" :key="page" @click="handlePageClick(page)">{{ page }}</button>
+      </div>
+    </div>
+        </div>
+      </div>
+    </div>
+</template>
+<script setup>
+import MainSideBarComponent from "@/components/recruiter/MainSideBarComponent.vue";
+import { computed, onMounted, ref } from "vue";
+import MainHeaderComponent from "../../../components/recruiter/MainHeaderComponent.vue";
+import { UseInterviewScheduleStore } from '@/stores/UseInterviewScheduleStore';
+import { useRouter } from "vue-router";
+  
+const interviewScheduleStore = UseInterviewScheduleStore();
+const router = useRouter();
+
+const totalAnnouncements = ref(0);
+const announcements = ref([]);
+const careerBase = ref('전체');
+const pageNum = ref(1);
+const currentPage = ref(1);
+const postsPerPage = 10; 
+
+onMounted(async () => {
+    announcements.value = await interviewScheduleStore.readAllAnnouncement(careerBase.value, pageNum.value);
+    totalAnnouncements.value = await interviewScheduleStore.getTotalAnnouncement(careerBase.value);
+})
+const startNumberForPage = computed(() => {
+  return totalAnnouncements.value - (currentPage.value - 1) * postsPerPage;
+});
+const totalPages = computed(() => {
+  return totalAnnouncements.value ? Math.ceil(totalAnnouncements.value / postsPerPage) : 0;
+});
+
+const handlePageClick = async(pageNumber) => {
+  currentPage.value = pageNumber; // 페이지 번호 업데이트
+  announcements.value = await interviewScheduleStore.readAllAnnouncement(careerBase.value, pageNumber);
+};
+
+const formatDate = (datetime) => {
+  const date = new Date(datetime);
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+const handleSearchButton = async (announcementIdx) => {
+  router.push(`/recruiter/interview-evaluate/result/${announcementIdx}`);
+}
+</script> 
+<style>
+.wrapper {
+    width: 80%;
+    margin: 0 auto;
+}
+  
+.container {
+    width: 80%;
+    flex: 1;
+    margin: 0 auto;
+    margin-left: 200px;
+    padding: 150px 0;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+}
+</style>
+    

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,7 +2,6 @@ import AnnounceMainPage from '@/pages/recruiter/announce/AnnounceMainPage.vue';
 import AnnounceDetailRcrPage from '@/pages/recruiter/announce/AnnounceDetailPage.vue';
 import RecruiterLoginPage from '@/pages/recruiter/auth/RecruiterLoginPage.vue';
 import RecruiterSignupPage from '@/pages/recruiter/auth/RecruiterSignupPage.vue';
-import InterviewEvaluateMain from '@/pages/recruiter/interview-evaluate/InterviewEvaluateFormMain.vue';
 import RecruiterResumeDetailPage from '@/pages/recruiter/resume/ResumeDetailPage.vue';
 import ResumeListPage from '@/pages/recruiter/resume/ResumeListPage.vue';
 import ResumeMainPage from '@/pages/recruiter/resume/ResumeMainPage.vue';
@@ -29,6 +28,9 @@ import InterviewScheduleMain from '@/components/recruiter/InterviewScheduleMain.
 import ReScheduleMainExp from "@/pages/recruiter/interview-schedule/ReScheduleMainExp.vue";
 import { UseAuthStore } from "@/stores/UseAuthStore";
 import CompanyInfoPage from "@/pages/recruiter/company/CompanyInfoPage.vue";
+import InterviewEvaluateFormPage from '@/pages/recruiter/interview-evaluate/InterviewEvaluateFormPage.vue';
+import InterviewEvaluateResultPage from '@/pages/recruiter/interview-evaluate/InterviewEvaluateResultPage.vue';
+import InterveiwEvaluateResultDetailPage from '@/pages/recruiter/interview-evaluate/InterveiwEvaluateResultDetailPage.vue';
 
 const requireRecruiterLogin = async (to, from, next) => {
     const authStore = UseAuthStore();
@@ -68,7 +70,9 @@ const router = createRouter({
         { path: '/recruiter/announce/register-step1', component: AnnounceRegisterStep1Page, beforeEnter: requireRecruiterLogin },
         { path: '/recruiter/interview-schedule/new', component: InterviewScheduleMainNew, beforeEnter: requireRecruiterLogin },
         { path: '/recruiter/interview-schedule/exp', component: InterviewScheduleMainExp, beforeEnter: requireRecruiterLogin },
-        { path: '/recruiter/interview-evaluate', component: InterviewEvaluateMain, beforeEnter: requireRecruiterLogin },
+        { path: '/recruiter/interview-evaluate/form', component: InterviewEvaluateFormPage, beforeEnter: requireRecruiterLogin },
+        { path: '/recruiter/interview-evaluate/result', component: InterviewEvaluateResultPage, beforeEnter: requireRecruiterLogin },
+        { path: '/recruiter/interview-evaluate/result/:announcementIdx', component: InterveiwEvaluateResultDetailPage, beforeEnter: requireRecruiterLogin },
 
         { path: '/video-interview/:announceUUID', component: VideoInterviewMainPage, },
         { path: '/video-interview/:announceUUID/:videoInterviewUUID', component: VideoInterviewRoomPage },

--- a/frontend/src/stores/UseInterviewEvaluateStore.js
+++ b/frontend/src/stores/UseInterviewEvaluateStore.js
@@ -61,6 +61,20 @@ export const UseInterviewEvaluateStore = defineStore('interviewEvaluate', {
             } catch (error) {
                 return error.response.data
             }
+        },
+        async readAllEvaluate(announceIdx) {
+            try {
+                const response = await axios.get(
+                    `${backend}/interview-evaluate/read-all/evaluate?announceIdx=${announceIdx}`,
+                    {
+                        headers: { 'Content-Type': 'application/json', },
+                        withCredentials: true
+                    }
+                );
+                return response.data
+            } catch (error) {
+                return error.response.data
+            }
         }
     },
 });


### PR DESCRIPTION
## 💭 연관된 이슈
closed #241 
<br>
## 📌 구현 목표
채용담당자 화상 면접 평가 목록 조회 페이지 개발
<br>
## ✅ 주요구현 기능
1.  MainHeaderComponent와 MainSideBarComponent를 이용한 페이지 레이아웃 구성
2. onMounted 훅을 사용해 컴포넌트 마운트 시 면접 평가 데이터를 API에서 불러오도록 설정
3. Object.entries()를 활용하여 interviewEvaluateResult 데이터를 테이블 형식으로 출력
4. vue-toastification 라이브러리를 사용해 데이터 호출 성공 시 사용자에게 알림 메시지 표시
5. v-for를 이용해 면접 평가 결과(이름, 총점, 코멘트, 이메일)를 반복하여 테이블에 표시
