### PR TITLE
[#57][Feat] 채용담당자 화상 면접 평가 상세 조회 개발

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/controller/InterviewEvaluateController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/controller/InterviewEvaluateController.java
@@ -70,4 +70,5 @@ public class InterviewEvaluateController {
         InterviewEvaluateReadAllRes response = interviewEvaluateService.readAllEvaluate(customUserDetails, announceIdx);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.INTERVIEW_EVALUATE_READ_ALL_SUCCESS, response));
     }
+
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateReadRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateReadRes.java
@@ -12,4 +12,6 @@ public class InterviewEvaluateReadRes {
     private Integer totalScore;
     private String comments;
     private String estimatorEmail;
+    private InterviewEvaluateFormReadRes interviewEvaluateFormReadRes;
+    private InterviewEvaluateResultReadRes interviewEvaluateResultReadRes;
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateResultReadRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateResultReadRes.java
@@ -1,0 +1,21 @@
+package com.sabujaks.irs.domain.interview_evaluate.model.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewEvaluateResultReadRes {
+    private Integer r1;
+    private Integer r2;
+    private Integer r3;
+    private Integer r4;
+    private Integer r5;
+    private Integer r6;
+    private Integer r7;
+    private Integer r8;
+    private Integer r9;
+    private Integer r10;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/service/InterviewEvaluateService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/service/InterviewEvaluateService.java
@@ -458,11 +458,37 @@ public class InterviewEvaluateService {
             for(InterviewParticipate interviewParticipate : interviewParticipateList){
                 InterviewEvaluate interviewEvaluate = interviewEvaluateRepository.findByInterviewParticipateIdx(interviewParticipate.getIdx())
                         .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_READ_ALL_FAIL));
+                InterviewEvaluateResultReadRes interviewEvaluateResultReadRes = InterviewEvaluateResultReadRes.builder()
+                        .r1(interviewEvaluate.getInterviewEvaluateResult().getR1())
+                        .r2(interviewEvaluate.getInterviewEvaluateResult().getR2())
+                        .r3(interviewEvaluate.getInterviewEvaluateResult().getR3())
+                        .r4(interviewEvaluate.getInterviewEvaluateResult().getR4())
+                        .r5(interviewEvaluate.getInterviewEvaluateResult().getR5())
+                        .r6(interviewEvaluate.getInterviewEvaluateResult().getR6())
+                        .r7(interviewEvaluate.getInterviewEvaluateResult().getR7())
+                        .r8(interviewEvaluate.getInterviewEvaluateResult().getR8())
+                        .r9(interviewEvaluate.getInterviewEvaluateResult().getR9())
+                        .r10(interviewEvaluate.getInterviewEvaluateResult().getR10())
+                        .build();
+                InterviewEvaluateFormReadRes interviewEvaluateFormReadRes = InterviewEvaluateFormReadRes.builder()
+                        .q1(interviewEvaluate.getInterviewEvaluateForm().getQ1())
+                        .q2(interviewEvaluate.getInterviewEvaluateForm().getQ2())
+                        .q3(interviewEvaluate.getInterviewEvaluateForm().getQ3())
+                        .q4(interviewEvaluate.getInterviewEvaluateForm().getQ4())
+                        .q5(interviewEvaluate.getInterviewEvaluateForm().getQ5())
+                        .q6(interviewEvaluate.getInterviewEvaluateForm().getQ6())
+                        .q7(interviewEvaluate.getInterviewEvaluateForm().getQ7())
+                        .q8(interviewEvaluate.getInterviewEvaluateForm().getQ8())
+                        .q9(interviewEvaluate.getInterviewEvaluateForm().getQ9())
+                        .q10(interviewEvaluate.getInterviewEvaluateForm().getQ10())
+                        .build();
                 InterviewEvaluateReadRes interviewEvaluateReadRes = InterviewEvaluateReadRes.builder()
                         .estimatorEmail(interviewParticipate.getEstimator().getEmail())
                         .seekerName(interviewParticipate.getSeeker().getName())
                         .totalScore(interviewEvaluate.getTotalScore())
                         .comments(interviewEvaluate.getComments())
+                        .interviewEvaluateResultReadRes(interviewEvaluateResultReadRes)
+                        .interviewEvaluateFormReadRes(interviewEvaluateFormReadRes)
                         .build();
                 interviewEvaluateReadAllResMap.put(interviewParticipate.getSeeker().getIdx(), interviewEvaluateReadRes);
             }


### PR DESCRIPTION
## 💭 연관된 이슈
closed #57 
<br>
## 📌 구현 목표
채용담당자 화상 면접 평가 상세 조회 개발
<br>
## ✅ 주요구현 기능
1. announceIdx에 해당하는 공고(Announcement)를 announcementRepository에서 찾아옴, 없으면 예외
2. 조회된 공고의 채용담당자 이메일과 현재 사용자(customUserDetails)의 이메일을 비교해 일치하지 않으면 예외
3. 공고 idx로 interviewScheduleRepository에서 면접 일정을 조회, 조회된 면접 일정에 해당하는 면접 참여자 리스트 가져옴
4. 각 면접 참여자에 대해 interviewEvaluateRepository에서 평가 데이터를 조회 및 반환
5. 따로 상세 조회 컨트롤러를 만들지 않고, 목록조회시 평가항목과 평가항목별 점수를 가져오게 수정