### PR TITLE
[#66][Fix] 통합 지원서 관리 페이지 에러 수정

### DIFF
--- a/frontend/src/pages/seeker/mypage/MypageIntegrationeResumePage.vue
+++ b/frontend/src/pages/seeker/mypage/MypageIntegrationeResumePage.vue
@@ -16,7 +16,7 @@
                             <div class="resume-view-container">
                                 <div class="base profile image">
                                     <div class="container-p">
-                                        <div v-if="showPersonalInfo" class="photo"><img name="user_photo" :src="resumeStore.resumeIntegrated.personalInfo.profileImg">
+                                        <div v-if="showPersonalInfo" class="photo"><img name="user_photo" :src="resumeStore.resumeIntegrated.personalInfo.profileImg ? resumeStore.resumeIntegrated.personalInfo.profileImg : ''">
                                         </div>
                                         <div v-if="showPersonalInfo" class="info-container">
                                             <div class="info-general">


### PR DESCRIPTION
## 💭 연관된 이슈
closed: #66 
<br>

## 📌 구현 목표
지원자가 등록한 통합 지원서 상세 조회
<br>

## ✅ 주요구현 기능
통합지원서를 등록하지 않고 해당 페이지 접근 시 이미지가 없다는 에러가 뜨는 부분 수정