### PR TITLE
[#309][Feat] 채용담당자 화상 면접 평가 목록 조회 수정

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/controller/InterviewEvaluateController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/controller/InterviewEvaluateController.java
@@ -13,9 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.Map;
-
 
 @RestController
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateReadAllRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateReadAllRes.java
@@ -2,6 +2,7 @@ package com.sabujaks.irs.domain.interview_evaluate.model.response;
 
 import lombok.*;
 
+import java.util.List;
 import java.util.Map;
 
 @Getter
@@ -9,6 +10,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+
 public class InterviewEvaluateReadAllRes {
-    private Map<Long, InterviewEvaluateReadRes> interviewEvaluateReadResumeInfoResMap;
+    private Map<Long, List<InterviewEvaluateReadRes>> interviewEvaluateReadAllResMap;
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateReadRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/model/response/InterviewEvaluateReadRes.java
@@ -9,6 +9,7 @@ import lombok.*;
 @Builder
 public class InterviewEvaluateReadRes {
     private String seekerName;
+    private String seekerEmail;
     private Integer totalScore;
     private String comments;
     private String estimatorEmail;

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/repository/InterviewEvaluateRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/repository/InterviewEvaluateRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+import java.util.List;
 import java.util.Optional;
 
 @EnableJpaRepositories
@@ -13,5 +14,9 @@ public interface InterviewEvaluateRepository extends JpaRepository<InterviewEval
     @Query("SELECT ie FROM InterviewEvaluate ie WHERE ie.interviewParticipate.idx = :interviewParticipateIdx")
     Optional<InterviewEvaluate> findByInterviewParticipateIdx(Long interviewParticipateIdx);
 
+    @Query("SELECT ie FROM InterviewEvaluate ie " +
+            "WHERE ie.interviewParticipate.idx = :interviewParticipateIdx " +
+            "AND ie.interviewParticipate.seeker.idx = :seekerIdx")
+    Optional<List<InterviewEvaluate>> findAllByInterviewParticipateIdxAndSeekerIdx(Long interviewParticipateIdx, Long seekerIdx);
 }
 

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/service/InterviewEvaluateService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/service/InterviewEvaluateService.java
@@ -449,52 +449,62 @@ public class InterviewEvaluateService {
         if (!Objects.equals(announcement.getRecruiter().getEmail(), customUserDetails.getEmail())) {
             throw new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL_INVALID_REQUEST);
         }
-        Map<Long, InterviewEvaluateReadRes> interviewEvaluateReadAllResMap = new HashMap<>();
         List<InterviewSchedule> interviewScheduleList = interviewScheduleRepository.findByAnnouncementIdx(announceIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_SCHEDULE_NOT_FOUND));
+        Map<Long, List<InterviewEvaluateReadRes>> interviewEvaluateReadAllResMap = new HashMap<>();
         for(InterviewSchedule interviewSchedule : interviewScheduleList){
             List<InterviewParticipate> interviewParticipateList = interviewParticipateRepository.findByInterviewScheduleIdx(interviewSchedule.getIdx())
                     .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_PARTICIPATE_NOT_FOUND));
             for(InterviewParticipate interviewParticipate : interviewParticipateList){
-                InterviewEvaluate interviewEvaluate = interviewEvaluateRepository.findByInterviewParticipateIdx(interviewParticipate.getIdx())
+                List<InterviewEvaluate> interviewEvaluateList = interviewEvaluateRepository
+                        .findAllByInterviewParticipateIdxAndSeekerIdx(interviewParticipate.getIdx(), interviewParticipate.getSeeker().getIdx())
                         .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_EVALUATE_READ_ALL_FAIL));
-                InterviewEvaluateResultReadRes interviewEvaluateResultReadRes = InterviewEvaluateResultReadRes.builder()
-                        .r1(interviewEvaluate.getInterviewEvaluateResult().getR1())
-                        .r2(interviewEvaluate.getInterviewEvaluateResult().getR2())
-                        .r3(interviewEvaluate.getInterviewEvaluateResult().getR3())
-                        .r4(interviewEvaluate.getInterviewEvaluateResult().getR4())
-                        .r5(interviewEvaluate.getInterviewEvaluateResult().getR5())
-                        .r6(interviewEvaluate.getInterviewEvaluateResult().getR6())
-                        .r7(interviewEvaluate.getInterviewEvaluateResult().getR7())
-                        .r8(interviewEvaluate.getInterviewEvaluateResult().getR8())
-                        .r9(interviewEvaluate.getInterviewEvaluateResult().getR9())
-                        .r10(interviewEvaluate.getInterviewEvaluateResult().getR10())
-                        .build();
-                InterviewEvaluateFormReadRes interviewEvaluateFormReadRes = InterviewEvaluateFormReadRes.builder()
-                        .q1(interviewEvaluate.getInterviewEvaluateForm().getQ1())
-                        .q2(interviewEvaluate.getInterviewEvaluateForm().getQ2())
-                        .q3(interviewEvaluate.getInterviewEvaluateForm().getQ3())
-                        .q4(interviewEvaluate.getInterviewEvaluateForm().getQ4())
-                        .q5(interviewEvaluate.getInterviewEvaluateForm().getQ5())
-                        .q6(interviewEvaluate.getInterviewEvaluateForm().getQ6())
-                        .q7(interviewEvaluate.getInterviewEvaluateForm().getQ7())
-                        .q8(interviewEvaluate.getInterviewEvaluateForm().getQ8())
-                        .q9(interviewEvaluate.getInterviewEvaluateForm().getQ9())
-                        .q10(interviewEvaluate.getInterviewEvaluateForm().getQ10())
-                        .build();
-                InterviewEvaluateReadRes interviewEvaluateReadRes = InterviewEvaluateReadRes.builder()
-                        .estimatorEmail(interviewParticipate.getEstimator().getEmail())
-                        .seekerName(interviewParticipate.getSeeker().getName())
-                        .totalScore(interviewEvaluate.getTotalScore())
-                        .comments(interviewEvaluate.getComments())
-                        .interviewEvaluateResultReadRes(interviewEvaluateResultReadRes)
-                        .interviewEvaluateFormReadRes(interviewEvaluateFormReadRes)
-                        .build();
-                interviewEvaluateReadAllResMap.put(interviewParticipate.getSeeker().getIdx(), interviewEvaluateReadRes);
+                for(InterviewEvaluate interviewEvaluate : interviewEvaluateList){
+                    InterviewEvaluateResultReadRes interviewEvaluateResultReadRes = InterviewEvaluateResultReadRes.builder()
+                            .r1(interviewEvaluate.getInterviewEvaluateResult().getR1())
+                            .r2(interviewEvaluate.getInterviewEvaluateResult().getR2())
+                            .r3(interviewEvaluate.getInterviewEvaluateResult().getR3())
+                            .r4(interviewEvaluate.getInterviewEvaluateResult().getR4())
+                            .r5(interviewEvaluate.getInterviewEvaluateResult().getR5())
+                            .r6(interviewEvaluate.getInterviewEvaluateResult().getR6())
+                            .r7(interviewEvaluate.getInterviewEvaluateResult().getR7())
+                            .r8(interviewEvaluate.getInterviewEvaluateResult().getR8())
+                            .r9(interviewEvaluate.getInterviewEvaluateResult().getR9())
+                            .r10(interviewEvaluate.getInterviewEvaluateResult().getR10())
+                            .build();
+                    InterviewEvaluateFormReadRes interviewEvaluateFormReadRes = InterviewEvaluateFormReadRes.builder()
+                            .q1(interviewEvaluate.getInterviewEvaluateForm().getQ1())
+                            .q2(interviewEvaluate.getInterviewEvaluateForm().getQ2())
+                            .q3(interviewEvaluate.getInterviewEvaluateForm().getQ3())
+                            .q4(interviewEvaluate.getInterviewEvaluateForm().getQ4())
+                            .q5(interviewEvaluate.getInterviewEvaluateForm().getQ5())
+                            .q6(interviewEvaluate.getInterviewEvaluateForm().getQ6())
+                            .q7(interviewEvaluate.getInterviewEvaluateForm().getQ7())
+                            .q8(interviewEvaluate.getInterviewEvaluateForm().getQ8())
+                            .q9(interviewEvaluate.getInterviewEvaluateForm().getQ9())
+                            .q10(interviewEvaluate.getInterviewEvaluateForm().getQ10())
+                            .build();
+                    InterviewEvaluateReadRes interviewEvaluateReadRes = InterviewEvaluateReadRes.builder()
+                            .seekerName(interviewParticipate.getSeeker().getName())
+                            .seekerEmail(interviewParticipate.getSeeker().getEmail())
+                            .estimatorEmail(interviewParticipate.getEstimator().getEmail())
+                            .totalScore(interviewEvaluate.getTotalScore())
+                            .comments(interviewEvaluate.getComments())
+                            .interviewEvaluateResultReadRes(interviewEvaluateResultReadRes)
+                            .interviewEvaluateFormReadRes(interviewEvaluateFormReadRes)
+                            .build();
+                    if (interviewEvaluateReadAllResMap.containsKey(interviewParticipate.getSeeker().getIdx())) {
+                        interviewEvaluateReadAllResMap.get(interviewParticipate.getSeeker().getIdx()).add(interviewEvaluateReadRes);
+                    } else {
+                        List<InterviewEvaluateReadRes> interviewEvaluateReadResList = new ArrayList<>();
+                        interviewEvaluateReadResList.add(interviewEvaluateReadRes);
+                        interviewEvaluateReadAllResMap.put(interviewParticipate.getSeeker().getIdx(), interviewEvaluateReadResList);
+                    }
+                }
             }
         }
         return InterviewEvaluateReadAllRes.builder()
-                .interviewEvaluateReadResumeInfoResMap(interviewEvaluateReadAllResMap)
+                .interviewEvaluateReadAllResMap(interviewEvaluateReadAllResMap)
                 .build();
     }
 }


### PR DESCRIPTION
## 💭 연관된 이슈
closed #309 
<br>
## 📌 구현 목표
채용담당자 화상 면접 평가 목록 조회 수정
<br>
## ✅ 주요구현 기능
1.  주어진 announceIdx를 이용해 채용 공고를 검색하고, 요청을 한 사용자가 해당 채용 공고의 작성자인지 검증
2. 채용 공고에 해당하는 모든 면접 스케줄을 가져오고, 각 스케줄에 참여한 면접 참여자 목록을 가져옴
3. 각 면접 참여자의 면접 평가 정보를 가져와서, 지원자 별로 평가자들이 남긴 평가 점수, 평가 항목에 대한 응답 등을 객체로 저장
4. Map 구조로, Seeker ID를 키로 사용하여 각 지원자의 면접 평가 리스트를 저장합니다. 동일 지원자의 평가가 여러 개일 경우 리스트에 추가