### PR TITLE
[#49][Feat] 면접방 생성 후 이메일 전송을 위한 데이터 바인딩 처리

### DIFF
--- a/frontend/src/components/recruiter/InterviewScheduleList.vue
+++ b/frontend/src/components/recruiter/InterviewScheduleList.vue
@@ -62,8 +62,8 @@ const handleRowClick = (type) => {
   emit('openModal', type);
 }
 
-const createVideoInterview = (uuid) => {
-  emit('createVideoInterview', uuid);
+const createVideoInterview = (uuid, interviewScheduleInfo) => {
+  emit('createVideoInterview', uuid, interviewScheduleInfo);
 }
 
 const formatDate = (datetime) => {
@@ -120,7 +120,7 @@ const handleScheduleClick = (schedule) => {
           </ul>
         </td>
         <td>
-          <button @click="createVideoInterview(schedule.uuid)">방 생성</button>
+          <button @click="createVideoInterview(schedule.uuid, schedule)">방 생성</button>
         </td>
       </tr>
       </tbody>

--- a/frontend/src/components/recruiter/ReScheduleDetail.vue
+++ b/frontend/src/components/recruiter/ReScheduleDetail.vue
@@ -138,7 +138,8 @@ const submitForm = () => {
     // 갱신해야할 데이터 객체
     const updateInterviewData = {
       interviewScheduleIdx: props.interviewScheduleDetail.idx,
-      seekerList: selectedSpanValues
+      seekerList: selectedSpanValues,
+      reScheduleIdx: props.reScheduleInfo.idx
     }
 
     const pageUpdateData = {

--- a/frontend/src/pages/recruiter/interview-schedule/InterviewScheduleMainExp.vue
+++ b/frontend/src/pages/recruiter/interview-schedule/InterviewScheduleMainExp.vue
@@ -93,11 +93,11 @@ const loadInterviewScheduleList = async (btnNumValue) => {
   interviewSchedules.value = response; // 데이터를 가져온 후 interviewSchedules에 값을 할당
 };
 
-const createVideoInterview = async (interviewScheduleUuid) => {
+const createVideoInterview = async (interviewScheduleUuid, interviewScheduleInfo) => {
   uuidData.value = {
     announceUUID: announcementUuidInfo.value,
-    // videoInterviewUUID: interviewScheduleUuid,
-    params: {customSessionId: interviewScheduleUuid}
+    params: {customSessionId: interviewScheduleUuid},
+    interviewScheduleInfo: interviewScheduleInfo
   }
   const response = await interviewScheduleStore.createVideoInterview(uuidData.value);
   if (response !== 0 && response !== undefined) {

--- a/frontend/src/pages/recruiter/interview-schedule/InterviewScheduleMainNew.vue
+++ b/frontend/src/pages/recruiter/interview-schedule/InterviewScheduleMainNew.vue
@@ -93,11 +93,11 @@ const loadInterviewScheduleList = async (btnNumValue) => {
   interviewSchedules.value = response; // 데이터를 가져온 후 interviewSchedules에 값을 할당
 };
 
-const createVideoInterview = async (interviewScheduleUuid) => {
+const createVideoInterview = async (interviewScheduleUuid, interviewScheduleInfo) => {
   uuidData.value = {
     announceUUID: announcementUuidInfo.value,
-    // videoInterviewUUID: interviewScheduleUuid,
-    params: {customSessionId: interviewScheduleUuid}
+    params: {customSessionId: interviewScheduleUuid},
+    interviewScheduleInfo: interviewScheduleInfo
   }
   const response = await interviewScheduleStore.createVideoInterview(uuidData.value);
   if (response !== 0 && response !== undefined) {


### PR DESCRIPTION
## 💭 연관된 이슈
#49 
<br>

## 📌 구현 목표
채용담당자는 면접 일정이 확정되면, 이메일로 알림을 보낼 수 있다.
<br>

## ✅ 주요구현 기능
1. interview-list에서 list정보 전송
2. 경력, 신입 면접방 확정 이메일 전송을 위한 list 데이터 바인딩 처리