### PR TITLE
[#72][Fix] 지원자 지원서 제출 페이지 에러 수정

### DIFF
--- a/frontend/src/pages/seeker/resume/ResumeSubmitPage.vue
+++ b/frontend/src/pages/seeker/resume/ResumeSubmitPage.vue
@@ -236,17 +236,19 @@ onMounted(async () => {
   const response = await resumeStore.readSubmitInfo(route.params.announcementIdx);
 
   showPersonalInfo.value = true;
-  showEducation.value = response.result.codes.includes("resume_001");
-  showPersonalHistory.value = response.result.codes.includes("resume_002");
-  showInternsActivity.value = response.result.codes.includes("resume_003");
-  showTraining.value = response.result.codes.includes("resume_004");
-  showCertification.value = response.result.codes.includes("resume_005");
-  showAward.value = response.result.codes.includes("resume_006");
-  showStudyingAbroad.value = response.result.codes.includes("resume_007");
-  showLanguage.value = response.result.codes.includes("resume_008");
-  showPortfolio.value = response.result.codes.includes("resume_009");
-  showPreferentialEmp.value = response.result.codes.includes("resume_010");
-  showCustomLetter.value = response.result.codes.includes("resume_011");
+  if(resumeStore.resumeIntegrated.codes) {
+    showEducation.value = response.result.codes.includes("resume_001");
+    showPersonalHistory.value = response.result.codes.includes("resume_002");
+    showInternsActivity.value = response.result.codes.includes("resume_003");
+    showTraining.value = response.result.codes.includes("resume_004");
+    showCertification.value = response.result.codes.includes("resume_005");
+    showAward.value = response.result.codes.includes("resume_006");
+    showStudyingAbroad.value = response.result.codes.includes("resume_007");
+    showLanguage.value = response.result.codes.includes("resume_008");
+    showPortfolio.value = response.result.codes.includes("resume_009");
+    showPreferentialEmp.value = response.result.codes.includes("resume_010");
+    showCustomLetter.value = response.result.codes.includes("resume_011");
+  }
   // 자기소개서 (맞춤)
   if(showCustomLetter.value) {
     customLetterActivities.value = response.result.customLetterForms.map((customLetterForm, index) => ({


### PR DESCRIPTION
## 💭 연관된 이슈
closed: #72 
<br>

## 📌 구현 목표
지원자가 공고에 제출할 지원서를 작성하기 위해 지원서 제출 페이지 접근 시 나는 에러 수정
<br>

## ✅ 주요구현 기능
지원서 항목이 없을 때 해당 페이지 접근 시 에러가 뜨는 부분 수정