### PR TITLE
[#146][Feat] 지원자 & 면접진 화상 면접방 시간대 접근 제어 개발

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/video_interview/service/VideoInterviewService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/video_interview/service/VideoInterviewService.java
@@ -17,12 +17,14 @@ import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
 import com.sabujaks.irs.global.security.CustomUserDetails;
 import io.openvidu.java.client.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -81,9 +83,14 @@ public class VideoInterviewService {
     }
 
     public VideoInterviewTokenGetRes sessionToken(VideoInterviewTokenGetReq dto, CustomUserDetails userDetails) throws BaseException, OpenViduJavaClientException, OpenViduHttpException {
+        boolean result = checkUserAuthorities(userDetails, dto);
+        if(!result){
+            throw new BaseException(BaseResponseMessage.VIDEO_INTERVIEW_JOIN_FAIL_NOT_TIME);
+        }
         Session session = openVidu.getActiveSession(dto.getVideoInterviewUUID());
         if (session == null) { throw new BaseException(BaseResponseMessage.VIDEO_INTERVIEW_JOIN_FAIL);}
         ConnectionProperties properties = ConnectionProperties.fromJson(dto.getParams()).build();
+
         try{
             Connection connection = session.createConnection(properties);
             return VideoInterviewTokenGetRes.builder()
@@ -106,5 +113,44 @@ public class VideoInterviewService {
         }
     }
 
+
+        public boolean checkUserAuthorities(CustomUserDetails userDetails, VideoInterviewTokenGetReq dto) {
+            // 현재 시스템 시간
+            LocalDateTime currentTime = LocalDateTime.now();
+
+            // 권한 스트링 형식: "ROLE_SEEKER|id1|id2|날짜|시작시간|종료시간"
+            Collection< ? extends GrantedAuthority> authorities = userDetails.getVideoInterviewAuthorities();
+
+            for (GrantedAuthority authority : authorities) {
+                String authorityStr = authority.getAuthority();
+                String[] parts = authorityStr.split("\\|");
+                if (parts.length == 6) {
+                    String role = parts[0];
+                    System.out.println(role);
+                    String id1 = parts[1];
+                    System.out.println(id1);
+                    String id2 = parts[2];
+                    System.out.println(id2);
+                    String date = parts[3];
+                    System.out.println(date);
+                    String startTime = parts[4];
+                    System.out.println(startTime);
+                    String endTime = parts[5];
+                    System.out.println(endTime);
+                    if(Objects.equals(id1, dto.getAnnounceUUID()) && Objects.equals(id2, dto.getVideoInterviewUUID())){
+                        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+                        LocalDateTime startDateTime = LocalDateTime.parse(date + " " + startTime, dateFormatter);
+                        LocalDateTime endDateTime = LocalDateTime.parse(date + " " + endTime, dateFormatter);
+                        LocalDateTime startDateTimeWithBuffer = startDateTime.minusMinutes(3);
+                        if (currentTime.isAfter(startDateTimeWithBuffer) && currentTime.isBefore(endDateTime)) {
+                            System.out.println("권한이 유효합니다: " + role);
+                            return true;
+                        }
+                    }
+
+                }
+            }
+            return false;
+        }
 }
 

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -66,7 +66,7 @@ public enum BaseResponseMessage {
     VIDEO_INTERVIEW_SEARCH_ALL_FAIL(false, 1402, "화상 면접방 목록 조회에 실패했습니다."),
     VIDEO_INTERVIEW_JOIN_SUCCESS(true, 1403, "화상 면접방에 참가했습니다."),
     VIDEO_INTERVIEW_JOIN_FAIL(false, 1404, "화상 면접방 참가에 실패했습니다."),
-
+    VIDEO_INTERVIEW_JOIN_FAIL_NOT_TIME(false, 1405, "참여 시간대가 아닙니다. 참여 시간을 맞춘뒤 접속해주세요."),
     // MEMBER 1500
     MEMBER_NOT_FOUND(false, 1500, "회원을 찾을 수 없습니다."),
     ESTIMATOR_NOT_FOUND(false, 1501, "면접관을 찾을 수 없습니다."),


### PR DESCRIPTION
## 💭 연관된 이슈
closed: #146 
<br>

## 📌 구현 목표
지원자가 공고에 제출할 지원서를 작성하기 위해 지원서 제출 페이지 접근 시 나는 에러 수정
<br>

## ✅ 주요구현 기능
 1. OpenVidu를 사용해 화상 면접 기능을 구현
 2. 스프링 시큐리티로 자기 시간대가 아니거나 자신의 면접방이 아닌경우 접근을 제한함
 3. 면접관 엔티티 추가 연관관계 매핑, 면접 일정 기능 수정
 4. 지원자, 채용 담당자, 면접진 공고 면접 목록 조회 및 면접방에 대한 접근제어 수행
 5. 토큰 기반으로 권한을 저장하고 jwtFilter에서 권한 설정 및 Security가 권한기반 접근제어 수행
 6. 지원자의권한이 ROLE_SEEKER|df9333c3-f843-4e11-a12a-ba43cfc22642|29306f9d-2407-4323-84db-7. 7c09f53722a5|2024.09.28|12:00|15:00일때 | 같은 공고라도 2024.09.28 12:00~15:00 에 진행되는 면접방에만 참가 가능
8. VideoInterviewService에서 get-access-token 요청시 권한을 조회하고, 시스템 시간과 비교해 예외처리
9. checkUserAuthorities() 메소드
   - 사용자 권한을 순회하면서 입력된 AnnounceUUID와 VideoInterviewUUID가 일치하는지 확인
   - 권한의 시간 범위(시작 시간 3분 전부터 종료 시간까지)가 현재 시간 내에 있는지 검증
   - 유효하면 true를 반환하고, 그렇지 않으면 false를 반환하여 권한을 검증