### PR TITLE
[#326][Feat] 면접 일정 생성 인터뷰 차수 설정 추가

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/InterviewSchedule.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/InterviewSchedule.java
@@ -41,6 +41,9 @@ public class InterviewSchedule {
     @Column(nullable = false)
     private String careerBase;
 
+    @Column(nullable = false)
+    private Integer interviewNum;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recruiter_idx")
     private Recruiter recruiter;

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/request/InterviewScheduleReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/request/InterviewScheduleReq.java
@@ -15,6 +15,7 @@ public class InterviewScheduleReq {
     private String interviewStart;
     private String interviewEnd;
     private String careerBase;
+    private Integer interviewNum;
     private Long announcementIdx;
     private Long teamIdx;
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/response/InterviewScheduleRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/response/InterviewScheduleRes.java
@@ -17,6 +17,7 @@ public class InterviewScheduleRes {
     private String interviewDate;
     private String interviewStart;
     private String interviewEnd;
+    private Integer interviewNum;
     private String uuid;
     private String careerBase;
     private Long teamIdx;

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/service/InterviewScheduleService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/service/InterviewScheduleService.java
@@ -37,6 +37,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.*;
@@ -58,6 +59,7 @@ public class InterviewScheduleService {
     private final ResumeRepository resumeRepository;
     private final CompanyRepository companyRepository;
 
+    @Transactional
     public InterviewScheduleRes create(CustomUserDetails customUserDetails, InterviewScheduleReq dto) throws BaseException {
         String uuid = uuidCheck(dto);
         Recruiter recruiter = recruiterRepository.findByRecruiterIdx(customUserDetails.getIdx())
@@ -74,6 +76,7 @@ public class InterviewScheduleService {
                 .interviewDate(dto.getInterviewDate())
                 .interviewStart(dto.getInterviewStart())
                 .interviewEnd(dto.getInterviewEnd())
+                .interviewNum(dto.getInterviewNum())
                 .uuid(uuid)
                 .careerBase(dto.getCareerBase())
                 .recruiter(recruiter)
@@ -149,6 +152,7 @@ public class InterviewScheduleService {
                 .interviewDate(interviewSchedule.getInterviewDate())
                 .interviewEnd(interviewSchedule.getInterviewEnd())
                 .interviewStart(interviewSchedule.getInterviewStart())
+                .interviewNum(interviewSchedule.getInterviewNum())
                 .uuid(interviewSchedule.getUuid())
                 .seekerList(seekerInfoGetResList)
                 .careerBase(interviewSchedule.getCareerBase())


### PR DESCRIPTION
## 💭 연관된 이슈
closed: #326 
<br>

## 📌 구현 목표
채용담당자는 면접 일정등록시, 몇차 면접인지 지정할 수 있다.
<br>

## ✅ 주요구현 기능
1. InterviewSchedule Entity 수정
2. InterviewSchedule Service 수정
3. InterviewSchedule dto 수정