### PR TITLE
[#331][Feat] 공고 지원 통합 프로세스 생성 개발

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/model/entity/Announcement.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/model/entity/Announcement.java
@@ -2,7 +2,7 @@ package com.sabujaks.irs.domain.announcement.model.entity;
 
 import com.sabujaks.irs.domain.auth.model.entity.Recruiter;
 import com.sabujaks.irs.domain.interview_evaluate.model.entity.InterviewEvaluateForm;
-import com.sabujaks.irs.domain.interview_evaluate.model.entity.TotalProcess;
+import com.sabujaks.irs.domain.total_process.model.entity.TotalProcess;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/backend/src/main/java/com/sabujaks/irs/domain/auth/model/entity/Seeker.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/auth/model/entity/Seeker.java
@@ -1,11 +1,8 @@
 package com.sabujaks.irs.domain.auth.model.entity;
 
 import com.sabujaks.irs.domain.alarm.model.entity.Alarm;
-import com.sabujaks.irs.domain.interview_evaluate.model.entity.InterviewEvaluate;
-import com.sabujaks.irs.domain.interview_evaluate.model.entity.InterviewEvaluateForm;
-import com.sabujaks.irs.domain.interview_evaluate.model.entity.TotalProcess;
+import com.sabujaks.irs.domain.total_process.model.entity.TotalProcess;
 import com.sabujaks.irs.domain.interview_schedule.model.entity.InterviewParticipate;
-import com.sabujaks.irs.domain.interview_schedule.model.entity.InterviewSchedule;
 import com.sabujaks.irs.domain.interview_schedule.model.entity.ReSchedule;
 import com.sabujaks.irs.domain.resume.model.entity.Resume;
 import com.sabujaks.irs.domain.resume.model.entity.ResumeInfo;
@@ -18,7 +15,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 // 지원자 엔티티
 @Entity

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/service/InterviewEvaluateService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_evaluate/service/InterviewEvaluateService.java
@@ -5,6 +5,7 @@ import com.sabujaks.irs.domain.announcement.model.entity.CustomLetterForm;
 import com.sabujaks.irs.domain.announcement.repository.AnnouncementRepository;
 import com.sabujaks.irs.domain.announcement.repository.CustomLetterFormRepository;
 import com.sabujaks.irs.domain.auth.model.entity.Seeker;
+import com.sabujaks.irs.domain.auth.repository.SeekerRepository;
 import com.sabujaks.irs.domain.interview_evaluate.model.entity.InterviewEvaluate;
 import com.sabujaks.irs.domain.interview_evaluate.model.entity.InterviewEvaluateForm;
 import com.sabujaks.irs.domain.interview_evaluate.model.entity.InterviewEvaluateResult;
@@ -33,6 +34,7 @@ import java.util.*;
 @Service
 @RequiredArgsConstructor
 public class InterviewEvaluateService {
+    private final SeekerRepository seekerRepository;
     private final InterviewEvaluateRepository interviewEvaluateRepository;
     private final InterviewEvaluateFormRepository interviewEvaluateFormRepository;
     private final InterviewParticipateRepository interviewParticipateRepository;
@@ -441,13 +443,13 @@ public class InterviewEvaluateService {
         }
     }
 
-    public InterviewEvaluateReadAllRes readAllEvaluate(CustomUserDetails customUserDetails, Long announceIdx, Integer interviewNum) throws BaseException {
-        Announcement announcement = announcementRepository.findByAnnounceIdx(announceIdx)
-                .orElseThrow(() -> new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL_NOT_FOUND));
+    public InterviewEvaluateReadAllRes readAllEvaluate(CustomUserDetails customUserDetails, Long announcementIdx, Integer interviewNum) throws BaseException {
+        Announcement announcement = announcementRepository.findByAnnounceIdx(announcementIdx)
+        .orElseThrow(() -> new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL_NOT_FOUND));
         if (!Objects.equals(announcement.getRecruiter().getEmail(), customUserDetails.getEmail())) {
             throw new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL_INVALID_REQUEST);
         }
-        List<InterviewSchedule> interviewScheduleList = interviewScheduleRepository.findAllByAnnouncementIdxAndInterviewNum(announceIdx, interviewNum)
+        List<InterviewSchedule> interviewScheduleList = interviewScheduleRepository.findAllByAnnouncementIdxAndInterviewNum(announcementIdx, interviewNum)
         .orElseThrow(() -> new BaseException(BaseResponseMessage.INTERVIEW_SCHEDULE_NOT_FOUND));
         Map<Long, List<InterviewEvaluateReadRes>> interviewEvaluateReadAllResMap = new HashMap<>();
         for(InterviewSchedule interviewSchedule : interviewScheduleList){
@@ -505,4 +507,6 @@ public class InterviewEvaluateService {
                 .interviewEvaluateReadAllResMap(interviewEvaluateReadAllResMap)
                 .build();
     }
+
+
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/total_process/controller/TotalProcessController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/total_process/controller/TotalProcessController.java
@@ -1,0 +1,31 @@
+package com.sabujaks.irs.domain.total_process.controller;
+
+import com.sabujaks.irs.domain.total_process.model.request.TotalProcessCreateReq;
+import com.sabujaks.irs.domain.total_process.model.response.TotalProcessCreateRes;
+import com.sabujaks.irs.domain.total_process.service.TotalProcessService;
+import com.sabujaks.irs.global.common.exception.BaseException;
+import com.sabujaks.irs.global.common.responses.BaseResponse;
+import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
+import com.sabujaks.irs.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/total-process")
+public class TotalProcessController {
+    private final TotalProcessService totalProcessService;
+    
+    @PostMapping("/create")
+    public ResponseEntity<BaseResponse<TotalProcessCreateRes>> create(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody TotalProcessCreateReq dto) throws BaseException {
+        TotalProcessCreateRes response = totalProcessService.create(dto, customUserDetails);
+        return ResponseEntity.ok(new BaseResponse<>(BaseResponseMessage.TOTAL_PROCESS_CREATE_SUCCESS, response));
+    }
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/total_process/model/entity/TotalProcess.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/total_process/model/entity/TotalProcess.java
@@ -1,4 +1,4 @@
-package com.sabujaks.irs.domain.interview_evaluate.model.entity;
+package com.sabujaks.irs.domain.total_process.model.entity;
 
 import com.sabujaks.irs.domain.announcement.model.entity.Announcement;
 import com.sabujaks.irs.domain.auth.model.entity.Seeker;

--- a/backend/src/main/java/com/sabujaks/irs/domain/total_process/model/request/TotalProcessCreateReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/total_process/model/request/TotalProcessCreateReq.java
@@ -1,0 +1,15 @@
+package com.sabujaks.irs.domain.total_process.model.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TotalProcessCreateReq {
+    private Long announcementIdx;
+    private Long seekerIdx;
+    private Integer interviewNum;
+    private Integer isPass;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/total_process/model/response/TotalProcessCreateRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/total_process/model/response/TotalProcessCreateRes.java
@@ -1,0 +1,12 @@
+package com.sabujaks.irs.domain.total_process.model.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TotalProcessCreateRes {
+    private Long idx;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/total_process/repository/TotalProcessRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/total_process/repository/TotalProcessRepository.java
@@ -1,0 +1,18 @@
+package com.sabujaks.irs.domain.total_process.repository;
+
+import com.sabujaks.irs.domain.interview_evaluate.model.entity.InterviewEvaluate;
+import com.sabujaks.irs.domain.total_process.model.entity.TotalProcess;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import java.util.List;
+import java.util.Optional;
+
+@EnableJpaRepositories
+public interface TotalProcessRepository extends JpaRepository<TotalProcess, Long> {
+    @Query("SELECT tp FROM TotalProcess tp " +
+            "WHERE tp.announcement.idx = :announcementIdx " +
+            "AND tp.seeker.idx = :seekerIdx")
+    Optional<TotalProcess> findByAnnouncementIdxAndSeekerIdx(Long announcementIdx, Long seekerIdx);
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/total_process/service/TotalProcessService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/total_process/service/TotalProcessService.java
@@ -1,0 +1,88 @@
+package com.sabujaks.irs.domain.total_process.service;
+
+import com.sabujaks.irs.domain.announcement.model.entity.Announcement;
+import com.sabujaks.irs.domain.announcement.repository.AnnouncementRepository;
+import com.sabujaks.irs.domain.auth.model.entity.Seeker;
+import com.sabujaks.irs.domain.auth.repository.SeekerRepository;
+import com.sabujaks.irs.domain.total_process.model.entity.TotalProcess;
+import com.sabujaks.irs.domain.total_process.model.request.TotalProcessCreateReq;
+import com.sabujaks.irs.domain.total_process.model.response.TotalProcessCreateRes;
+import com.sabujaks.irs.domain.total_process.repository.TotalProcessRepository;
+import com.sabujaks.irs.global.common.exception.BaseException;
+import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
+import com.sabujaks.irs.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TotalProcessService {
+    private final AnnouncementRepository announcementRepository;
+    private final SeekerRepository seekerRepository;
+    private final TotalProcessRepository totalProcessRepository;
+
+    public TotalProcessCreateRes create(TotalProcessCreateReq dto, CustomUserDetails customUserDetails) throws BaseException {
+        Announcement announcement = announcementRepository.findByAnnounceIdx(dto.getAnnouncementIdx())
+        .orElseThrow(() -> new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL_NOT_FOUND));
+        if(!Objects.equals(announcement.getRecruiter().getIdx(), customUserDetails.getRecruiter().getIdx())) {
+            throw new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL_INVALID_REQUEST);
+        }
+        Seeker seeker = seekerRepository.findBySeekerIdx(dto.getSeekerIdx())
+        .orElseThrow(() -> new BaseException(BaseResponseMessage.MEMBER_NOT_FOUND));
+        Optional<TotalProcess> result = totalProcessRepository.findByAnnouncementIdxAndSeekerIdx(dto.getAnnouncementIdx(), dto.getSeekerIdx());
+        Boolean isPassFlag = dto.getIsPass() == 1;
+        if(result.isPresent()){
+            TotalProcess totalProcess = result.get();
+            if(dto.getInterviewNum() == 0) {
+                totalProcess.setResumeResult(isPassFlag);
+            } else if(dto.getInterviewNum() == 1) {
+                totalProcess.setInterviewOneResult(isPassFlag);
+            }  else if (dto.getInterviewNum() == 2) {
+                totalProcess.setInterviewTwoResult(isPassFlag);
+            } else if (dto.getInterviewNum() == 3) {
+                totalProcess.setInterviewTwoResult(isPassFlag);
+            }
+            totalProcess.setAnnouncement(announcement);
+            totalProcess.setSeeker(seeker);
+            return TotalProcessCreateRes.builder()
+                    .idx(totalProcess.getIdx())
+                    .build();
+        }else {
+            TotalProcess totalProcess = null;
+            if(dto.getInterviewNum() == 0) {
+                totalProcess = TotalProcess.builder()
+                        .resumeResult(isPassFlag)
+                        .announcement(announcement)
+                        .seeker(seeker)
+                        .build();
+            } else if(dto.getInterviewNum() == 1) {
+                totalProcess = TotalProcess.builder()
+                        .interviewOneResult(isPassFlag)
+                        .announcement(announcement)
+                        .seeker(seeker)
+                        .build();
+            }  else if (dto.getInterviewNum() == 2) {
+                totalProcess = TotalProcess.builder()
+                        .interviewOneResult(isPassFlag)
+                        .announcement(announcement)
+                        .seeker(seeker)
+                        .build();
+            } else if (dto.getInterviewNum() == 3) {
+                totalProcess = TotalProcess.builder()
+                        .interviewOneResult(isPassFlag)
+                        .announcement(announcement)
+                        .seeker(seeker)
+                        .build();
+            } else {
+                throw new BaseException(BaseResponseMessage.TOTAL_PROCESS_CREATE_FAIL);
+            }
+            totalProcessRepository.save(totalProcess);
+            return TotalProcessCreateRes.builder()
+                    .idx(totalProcess.getIdx())
+                    .build();
+        }
+    }
+}

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -144,8 +144,10 @@ public enum BaseResponseMessage {
     INTERVIEW_EVALUATE_READ_ALL_FAIL(true, 6401, "지원자들의 면접 평가 결과를 불러오는데 실패했습니다."),
 
     // BASE_INFO 기준정보 관련 7000~7999
-    BASE_INFO_BENEFIT_CATEGORY_SEARCH_SUCCESS(true, 7000, "기준정보 중 복리후생 카테고리 조회에 성공했습니다.");
+    BASE_INFO_BENEFIT_CATEGORY_SEARCH_SUCCESS(true, 7000, "기준정보 중 복리후생 카테고리 조회에 성공했습니다."),
 
+    TOTAL_PROCESS_CREATE_SUCCESS(true, 8000, "통합 지원 프로세스 생성에 성공했습니다."),
+    TOTAL_PROCESS_CREATE_FAIL(true, 8001, "통합 지원 프로세스 생성에 실패했습니다.");
 
     private Boolean success;
     private Integer code;


### PR DESCRIPTION
## 💭 연관된 이슈
closed: #331 
<br>
## 📌 구현 목표
공고 지원 통합 프로세스 생성 개발
<br>
## ✅ 주요구현 기능
TotalProcess 엔티티, 컨트롤러, 서비스, DTO 생성
 create메소드: InterveiwNum(0: 서류, 1: 1차, 2: 2차 3: 최종)으로 각 지원 프로세스 별 결과를 지원자 ID, 공고 ID로 저장