### PR TITLE
[#340][Feat] 면접 일정 시간 필터링

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/controller/InterviewScheduleController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/controller/InterviewScheduleController.java
@@ -6,6 +6,7 @@ import com.sabujaks.irs.domain.interview_schedule.model.request.InterviewSchedul
 import com.sabujaks.irs.domain.interview_schedule.model.request.ReScheduleReq;
 import com.sabujaks.irs.domain.interview_schedule.model.response.InterviewScheduleRes;
 import com.sabujaks.irs.domain.interview_schedule.model.response.ReScheduleRes;
+import com.sabujaks.irs.domain.interview_schedule.model.response.TimeInfoRes;
 import com.sabujaks.irs.domain.interview_schedule.service.InterviewScheduleService;
 import com.sabujaks.irs.global.common.exception.BaseException;
 import com.sabujaks.irs.global.common.responses.BaseResponse;
@@ -105,5 +106,16 @@ public class InterviewScheduleController {
         List<SeekerInfoGetRes> response = interviewScheduleService.getSeekerList(announcementIdx);
 
         return ResponseEntity.ok(new BaseResponse<>(BaseResponseMessage.AUTH_SEARCH_USER_INFO_SUCCESS, response));
+    }
+
+    @GetMapping("/available-times")
+    public ResponseEntity<BaseResponse<?>> getAvailableTimes(
+            @RequestParam String interviewDate,
+            @RequestParam Long teamIdx,
+            @RequestParam Long announcementIdx) throws BaseException {
+
+        List<TimeInfoRes> response = interviewScheduleService.getAvailableTimes(interviewDate, teamIdx, announcementIdx);
+
+        return ResponseEntity.ok(new BaseResponse<>(BaseResponseMessage.INTERVIEW_SCHEDULE_AVAILABLE_TIMES_READ_SUCCESS, response));
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/InterviewParticipate.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/entity/InterviewParticipate.java
@@ -19,7 +19,7 @@ public class InterviewParticipate {
     private Long idx;
 
     @Setter
-    private Boolean status = true;
+    private Boolean status;
 
     @OneToMany(mappedBy = "interviewParticipate")
     private List<InterviewEvaluate> interviewEvaluateList;

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/response/TimeInfoRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/response/TimeInfoRes.java
@@ -1,0 +1,12 @@
+package com.sabujaks.irs.domain.interview_schedule.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TimeInfoRes {
+
+    private String interviewStart;
+    private String interviewEnd;
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/repository/InterviewScheduleRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/repository/InterviewScheduleRepository.java
@@ -51,4 +51,7 @@ public interface InterviewScheduleRepository extends JpaRepository<InterviewSche
 
     @Query("SELECT is FROM InterviewSchedule is WHERE is.announcement.idx = :announcementIdx AND is.interviewNum = :interviewNum")
     Optional<List<InterviewSchedule>> findAllByAnnouncementIdxAndInterviewNum(Long announcementIdx, Integer interviewNum);
+
+    @Query("SELECT is FROM InterviewSchedule is WHERE is.interviewDate = :interviewDate AND is.team.idx = :teamIdx AND is.announcement.idx = :announcementIdx")
+    Optional<List<InterviewSchedule>> findByInterviewDateAndTeamIdxAndAnnouncementIdx(String interviewDate, Long teamIdx, Long announcementIdx);
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/service/InterviewScheduleService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/service/InterviewScheduleService.java
@@ -20,6 +20,7 @@ import com.sabujaks.irs.domain.interview_schedule.model.request.InterviewSchedul
 import com.sabujaks.irs.domain.interview_schedule.model.request.ReScheduleReq;
 import com.sabujaks.irs.domain.interview_schedule.model.response.InterviewScheduleRes;
 import com.sabujaks.irs.domain.interview_schedule.model.response.ReScheduleRes;
+import com.sabujaks.irs.domain.interview_schedule.model.response.TimeInfoRes;
 import com.sabujaks.irs.domain.interview_schedule.repository.InterviewParticipateRepository;
 import com.sabujaks.irs.domain.interview_schedule.repository.InterviewScheduleRepository;
 import com.sabujaks.irs.domain.interview_schedule.repository.ReScheduleRepository;
@@ -108,6 +109,7 @@ public class InterviewScheduleService {
                 InterviewParticipate interviewParticipate = interviewParticipateRepository.save(InterviewParticipate.builder()
                         .seeker(seekerRepository.findBySeekerIdx(seekerIdx).orElseThrow(() -> new BaseException(BaseResponseMessage.MEMBER_NOT_FOUND)))
                         .estimator(estimator)
+                        .status(true)
                         .team(team)
                         .interviewSchedule(interviewSchedule)
                         .build());
@@ -454,5 +456,20 @@ public class InterviewScheduleService {
         }
 
         return seekerInfoGetResList;
+    }
+
+    public List<TimeInfoRes> getAvailableTimes(String interviewDate, Long teamIdx, Long announcementIdx) {
+
+        Optional<List<InterviewSchedule>> interviewScheduleList = interviewScheduleRepository.findByInterviewDateAndTeamIdxAndAnnouncementIdx(interviewDate, teamIdx, announcementIdx);
+
+        List<TimeInfoRes> timeInfoResList = new ArrayList<>();
+
+        for(InterviewSchedule interviewSchedule : interviewScheduleList.get()) {
+            timeInfoResList.add(TimeInfoRes.builder()
+                    .interviewStart(interviewSchedule.getInterviewStart())
+                    .interviewEnd(interviewSchedule.getInterviewEnd())
+                    .build());
+        }
+        return timeInfoResList;
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -57,6 +57,7 @@ public enum BaseResponseMessage {
     RESCHEDULE_SEARCH_ALL_SUCCESS(true, 1304, "면접 조율 내역 조회에 성공했습니다."),
     INTERVIEW_SCHEDULE_READ_ALL_SUCCESS(true, 1305, "면접 내역 조회에 성공했습니다."),
     INTERVIEW_SCHEDULE_UPDATE_SUCCESS(true, 1306, "면접 내역 업데이트에 성공했습니다."),
+    INTERVIEW_SCHEDULE_AVAILABLE_TIMES_READ_SUCCESS(true, 1307, "예약 가능한 시간대 조회에 성공했습니다."),
 
     INTERVIEW_PARTICIPATE_NOT_FOUND(false, 1320, "면접 연관 정보를 찾을 수 없습니다."),
 


### PR DESCRIPTION
## 💭 연관된 이슈
closed: #340 
<br>

## 📌 구현 목표
채용담당자는 면접 일정등록시, 등록 가능한 시간대만 조회할 수 있다.
<br>

## ✅ 주요구현 기능
1. InterviewSchedule Controller 수정
2. InterviewSchedule Service 수정
3. TimeInfoRes dto 생성