### PR TITLE
[#46][Fix] 채용담당자 서류 합불 로직구조 엔티티 구조 변경에 의한 로직 수정

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/controller/ResumeController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/controller/ResumeController.java
@@ -121,6 +121,7 @@ public class ResumeController {
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.RESUME_READ_SUCCESS, response));
     }
 
+    // 삭제 필요
     // (채용담당자) 서류 결과 업데이트
     @PatchMapping("/update/docPassed/{resumeIdx}")
     public ResponseEntity<BaseResponse<ResumeUpdateDocPassedRes>> updateDocPassed(

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/model/entity/Resume.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/model/entity/Resume.java
@@ -31,6 +31,7 @@ public class Resume {
     @CreationTimestamp
     private LocalDateTime resumedAt;
 
+    // 삭제 필요
     private Boolean docPassed;
 
     // 지원정보 테이블과 n:1
@@ -48,6 +49,7 @@ public class Resume {
     @JoinColumn(name = "seeker_idx")
     private Seeker seeker;
 
+    // 삭제 필요
     public Boolean updateDocPassed(Boolean docPassed) {
         if (this.docPassed == null) {
             this.docPassed = docPassed;

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/model/response/ResumeReadRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/model/response/ResumeReadRes.java
@@ -15,6 +15,8 @@ public class ResumeReadRes {
     private String resumeTitle;
     private LocalDateTime resumedAt;
     private Boolean docPassed;
+    private Long seekerIdx;
+    private Long announcementIdx;
     private PersonalInfoReadRes personalInfo; // 인적사항 1개
     private PreferentialEmpReadRes preferentialEmp; // 취업우대·병역 1개
     private List<EducationReadRes> educations; // 학력 n개

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/service/ResumeService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/service/ResumeService.java
@@ -16,6 +16,8 @@ import com.sabujaks.irs.domain.resume.model.entity.*;
 import com.sabujaks.irs.domain.resume.model.request.*;
 import com.sabujaks.irs.domain.resume.model.response.*;
 import com.sabujaks.irs.domain.resume.repository.*;
+import com.sabujaks.irs.domain.total_process.model.entity.TotalProcess;
+import com.sabujaks.irs.domain.total_process.repository.TotalProcessRepository;
 import com.sabujaks.irs.global.common.exception.BaseException;
 import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
 import com.sabujaks.irs.global.security.CustomUserDetails;
@@ -51,6 +53,7 @@ public class ResumeService {
     private final CustomFormRepository customFormRepository;
     private final RecruiterRepository recruiterRepository;
     private final CompanyRepository companyRepository;
+    private final TotalProcessRepository totalProcessRepository;
 
 
     @Transactional
@@ -1007,7 +1010,17 @@ public class ResumeService {
 
             responseBuilder.resumeTitle(resultResume.get().getResumeTitle());
             responseBuilder.resumedAt(resultResume.get().getResumedAt());
-            responseBuilder.docPassed(resultResume.get().getDocPassed());
+            responseBuilder.seekerIdx(resultResume.get().getSeeker().getIdx());
+            responseBuilder.announcementIdx(resultResume.get().getAnnouncement().getIdx());
+            // total_process 테이블에서 조회하기
+            Optional<TotalProcess> resultTotalProcess = totalProcessRepository.findByAnnouncementIdxAndSeekerIdx(
+                    resultResume.get().getAnnouncement().getIdx(), resultResume.get().getSeeker().getIdx()
+            );
+            if(resultTotalProcess.isPresent()) {
+                responseBuilder.docPassed(resultTotalProcess.get().getResumeResult());
+            } else {
+                responseBuilder.docPassed(null);
+            }
             // 지원정보 테이블 조회
             Optional<ResumeInfo> resultResumeInfo = resumeInfoRepository.findByResumeInfoIdx(resultResume.get().getResumeInfo().getIdx());
             if(resultResumeInfo.isPresent()) {
@@ -1256,6 +1269,7 @@ public class ResumeService {
 
     }
 
+    // 삭제 필요
     @Transactional
     public ResumeUpdateDocPassedRes updateDocPassed(
         CustomUserDetails customUserDetails,

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -147,7 +147,8 @@ public enum BaseResponseMessage {
     BASE_INFO_BENEFIT_CATEGORY_SEARCH_SUCCESS(true, 7000, "기준정보 중 복리후생 카테고리 조회에 성공했습니다."),
 
     TOTAL_PROCESS_CREATE_SUCCESS(true, 8000, "통합 지원 프로세스 생성에 성공했습니다."),
-    TOTAL_PROCESS_CREATE_FAIL(true, 8001, "통합 지원 프로세스 생성에 실패했습니다.");
+    TOTAL_PROCESS_CREATE_FAIL(true, 8001, "통합 지원 프로세스 생성에 실패했습니다."),
+    TOTAL_PROCESS_READ_FAIL(true, 8002, "통합 지원 프로세스 조회에 실패했습니다.");
 
     private Boolean success;
     private Integer code;


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
Fixes: #46 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
채용담당자가 지원자의 지원서에 대해 서류 합격/불합격 여부 선택
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
<br>

## ✅ 주요구현 기능
채용담당자가 서류 합불을 하기 위해 서류 합불 처리 여부나 합불 여부에 대해 조회 할 때 기존 공고지원서 테이블의 컬럼에서 조회하던 로직에서 새로운 테이블 total_process 테이블에서 조회하도록 수정

<br>

<br>

