### PR TITLE
[#80][Fix] 채용 담당자 서류 합불 엔티티 구조 변경에 의한 로직 수정

### DIFF
--- a/frontend/src/pages/recruiter/resume/ResumeDetailPage.vue
+++ b/frontend/src/pages/recruiter/resume/ResumeDetailPage.vue
@@ -474,7 +474,7 @@ const formatDate = (dateString) => {
 };
 
 const updateDocPassed = async (docPassedValue) => {
-    await resumeStore.updateDocPassed(route.params.resumeIdx, docPassedValue);
+    await resumeStore.updateDocPassed(docPassedValue);
 };
 
 </script>

--- a/frontend/src/stores/UseResumeStore.js
+++ b/frontend/src/stores/UseResumeStore.js
@@ -507,17 +507,22 @@ export const UseResumeStore = defineStore('resume', {
                 alert('공고별 지원서 조회에 실패하였습니다.');
             }
         },
-        async updateDocPassed(resumeIdx, docPassedValue) {
+        async updateDocPassed(docPassedValue) {
             try {
-                const response = await axios.patch(`${backend}/resume/update/docPassed/${resumeIdx}`, { docPassed: docPassedValue }, {
+                const response = await axios.post(`${backend}/total-process/create`, { 
+                    isPass: docPassedValue,
+                    announcementIdx: this.resumeDetail.announcementIdx,
+                    seekerIdx: this.resumeDetail.seekerIdx,
+                    interviewNum: 0
+                }, 
+                {
                     headers: { 'Content-Type': 'application/json' },
                     withCredentials: true
                 }
                 );
                 // 합격/불합격 처리 성공
-                if (confirm(response.data.message)) {
-                    location.reload();
-                }
+                alert(response.data.message);
+                location.reload();
             } catch (error) {
                 alert(error.response.data.message);
             }


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
Fixes: #80 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
채용담당자가 지원자의 지원서에 대해 서류 합격/불합격 여부 선택
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
<br>

## ✅ 주요구현 기능
채용담당자가 서류 결과를 합격 또는 불합격 처리 할 때 요청 url 변경
(기존 공고지원서의 컬럼만 변경해주었다면 total_process 테이블 생성)
<br>

<br>

