### PR TITLE
[#357][Fix] Video Interview 생성 event 동시 실행 수정

### DIFF
--- a/frontend/src/components/recruiter/InterviewScheduleList.vue
+++ b/frontend/src/components/recruiter/InterviewScheduleList.vue
@@ -62,7 +62,8 @@ const handleRowClick = (type) => {
   emit('openModal', type);
 }
 
-const createVideoInterview = (uuid, interviewScheduleInfo) => {
+const createVideoInterview = (uuid, interviewScheduleInfo, event) => {
+  event.stopPropagation();  // 이벤트 버블링 방지
   emit('createVideoInterview', uuid, interviewScheduleInfo);
 }
 
@@ -120,7 +121,7 @@ const handleScheduleClick = (schedule) => {
           </ul>
         </td>
         <td>
-          <button @click="createVideoInterview(schedule.uuid, schedule)">방 생성</button>
+          <button class="create-video-interview" @click="createVideoInterview(schedule.uuid, schedule, $event)">방 생성</button>
         </td>
       </tr>
       </tbody>
@@ -172,5 +173,12 @@ const handleScheduleClick = (schedule) => {
 .review-table tr:hover {
   background-color: #e6e6e6;
   cursor: pointer;
+}
+
+.create-video-interview {
+  background-color: #212b36;
+  color: white;
+  padding: 10px;
+  border-radius: 5px;
 }
 </style>


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #357 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
면접 일정 조회 페이지에서 방 생성 버튼과 해당 버튼이 있는 row 클릭 이벤트가 동시 실행되는 부분 수정했습니다.
<br>

## ✅ 주요 작업 부분
- 화상 면접 방 생성 버튼 클릭시 stopPropagation 추가
<br>
