### PR TITLE
[Feat] 각 채용 프로세스 결과 이메일 & 알람 일괄 전송 및 화상면접방 일괄 생성(동적스케줄링)

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/IrsApplication.java
+++ b/backend/src/main/java/com/sabujaks/irs/IrsApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableFeignClients
+@EnableScheduling
 public class IrsApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/sabujaks/irs/domain/alarm/service/AlarmService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/alarm/service/AlarmService.java
@@ -41,15 +41,20 @@ public class AlarmService {
         List<Alarm> result = alarmRepository.findBySeekerIdx(idx)
                                 .orElseThrow(() -> new BaseException(BaseResponseMessage.ALARM_SEARCH_FAIL));
         List<AlarmRes> alarmResult = new ArrayList<>();
-        for(Alarm alarm : result) {
-            alarmResult.add(AlarmRes.builder()
+        for (Alarm alarm : result) {
+            AlarmRes.AlarmResBuilder alarmResBuilder = AlarmRes.builder()
                     .idx(alarm.getIdx())
                     .type(alarm.getType())
                     .status(alarm.getStatus())
                     .message(alarm.getMessage())
-                    .createdAt(alarm.getCreatedAt())
-                    .interviewScheduleIdx(alarm.getInterviewSchedule().getIdx())
-                    .build());
+                    .createdAt(alarm.getCreatedAt());
+
+            // alarm.getInterviewSchedule()이 null이 아니면 interviewScheduleIdx 설정
+            if (alarm.getInterviewSchedule() != null) {
+                alarmResBuilder.interviewScheduleIdx(alarm.getInterviewSchedule().getIdx());
+            }
+
+            alarmResult.add(alarmResBuilder.build());
         }
 
         return alarmResult;

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/controller/InterviewScheduleController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/controller/InterviewScheduleController.java
@@ -12,7 +12,7 @@ import com.sabujaks.irs.global.common.exception.BaseException;
 import com.sabujaks.irs.global.common.responses.BaseResponse;
 import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
 import com.sabujaks.irs.global.security.CustomUserDetails;
-import com.sabujaks.irs.global.utils.EmailSenderSeeker;
+import com.sabujaks.irs.global.utils.email.service.EmailSenderSeeker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/backend/src/main/java/com/sabujaks/irs/domain/video_interview/controller/VideoInterviewController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/video_interview/controller/VideoInterviewController.java
@@ -1,6 +1,6 @@
 package com.sabujaks.irs.domain.video_interview.controller;
 
-import com.sabujaks.irs.domain.interview_schedule.model.request.InterviewScheduleReq;
+import com.sabujaks.irs.domain.video_interview.model.request.VideoInterviewCreateAllReq;
 import com.sabujaks.irs.domain.video_interview.model.request.VideoInterviewCreateReq;
 import com.sabujaks.irs.domain.video_interview.model.request.VideoInterviewTokenGetReq;
 import com.sabujaks.irs.domain.video_interview.model.response.VideoInterviewCreateRes;
@@ -11,7 +11,7 @@ import com.sabujaks.irs.global.common.exception.BaseException;
 import com.sabujaks.irs.global.common.responses.BaseResponse;
 import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
 import com.sabujaks.irs.global.security.CustomUserDetails;
-import com.sabujaks.irs.global.utils.EmailSenderSeeker;
+import com.sabujaks.irs.global.utils.email.service.EmailSenderSeeker;
 import io.openvidu.java.client.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,6 +52,15 @@ public class VideoInterviewController {
         @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @RequestBody VideoInterviewTokenGetReq dto) throws OpenViduJavaClientException, OpenViduHttpException, BaseException {
         VideoInterviewTokenGetRes response = videoInterviewService.sessionToken(dto, customUserDetails);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.VIDEO_INTERVIEW_JOIN_SUCCESS, response));
+    }
+
+    @PostMapping("/create-all")
+    public ResponseEntity<BaseResponse<?>> scheduleInterviewRoomCreation(
+            @RequestBody VideoInterviewCreateAllReq dto) throws BaseException, OpenViduJavaClientException, OpenViduHttpException {
+
+        String response = videoInterviewService.createAll(dto.getAnnouncementUuid(), dto.getAnnouncementIdx());
+
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.VIDEO_INTERVIEW_JOIN_SUCCESS, response));
     }
 

--- a/backend/src/main/java/com/sabujaks/irs/domain/video_interview/model/request/VideoInterviewCreateAllReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/video_interview/model/request/VideoInterviewCreateAllReq.java
@@ -1,0 +1,10 @@
+package com.sabujaks.irs.domain.video_interview.model.request;
+
+import lombok.*;
+
+@Getter
+@Builder
+public class VideoInterviewCreateAllReq {
+    private String announcementUuid;
+    private Long announcementIdx;
+}

--- a/backend/src/main/java/com/sabujaks/irs/global/config/SchedulerConfig.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/config/SchedulerConfig.java
@@ -1,0 +1,16 @@
+package com.sabujaks.irs.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5); // 스레드 풀 크기 설정
+        return scheduler;
+    }
+}
+

--- a/backend/src/main/java/com/sabujaks/irs/global/utils/email/model/response/ResumeRejectRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/utils/email/model/response/ResumeRejectRes.java
@@ -1,0 +1,14 @@
+package com.sabujaks.irs.global.utils.email.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResumeRejectRes {
+    private Long seekerIdx;
+    private String seekerName;
+    private String seekerEmail;
+    private String companyName;
+    private String announcementTitle;
+}

--- a/backend/src/main/java/com/sabujaks/irs/global/utils/email/service/EmailSenderEstimator.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/utils/email/service/EmailSenderEstimator.java
@@ -1,4 +1,4 @@
-package com.sabujaks.irs.global.utils;
+package com.sabujaks.irs.global.utils.email.service;
 
 
 import com.sabujaks.irs.domain.auth.model.response.SeekerInfoGetRes;

--- a/backend/src/main/java/com/sabujaks/irs/global/utils/email/service/EmailService.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/utils/email/service/EmailService.java
@@ -1,0 +1,47 @@
+package com.sabujaks.irs.global.utils.email.service;
+
+import com.sabujaks.irs.domain.company.model.entity.Company;
+import com.sabujaks.irs.domain.company.repository.CompanyRepository;
+import com.sabujaks.irs.domain.resume.model.entity.Resume;
+import com.sabujaks.irs.domain.resume.model.response.ResumeReadAllRecruiterRes;
+import com.sabujaks.irs.domain.resume.repository.ResumeRepository;
+import com.sabujaks.irs.global.security.CustomUserDetails;
+import com.sabujaks.irs.global.utils.email.model.response.ResumeRejectRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final ResumeRepository resumeRepository;
+    private final CompanyRepository companyRepository;
+
+    public List<ResumeRejectRes> getRejectInfo(CustomUserDetails customUserDetails, List<ResumeReadAllRecruiterRes> resumeList) {
+
+        Company company = companyRepository.findByRecruiterIdx(customUserDetails.getIdx()).get();
+
+        List<ResumeRejectRes> resumeRejectResList = new ArrayList<>();
+        for(ResumeReadAllRecruiterRes res: resumeList) {
+            Resume resume;
+            if(res.getResumeResult()) {
+                resume = resumeRepository.findByResumeIdx(res.getResumeIdx()).get();
+            } else {
+                continue;
+            }
+
+            resumeRejectResList.add(ResumeRejectRes.builder()
+                            .seekerIdx(resume.getSeeker().getIdx())
+                            .seekerName(resume.getSeeker().getName())
+                            .seekerEmail(resume.getSeeker().getEmail())
+                            .companyName(company.getName())
+                            .announcementTitle(resume.getAnnouncement().getTitle())
+                            .build());
+        }
+
+        return resumeRejectResList;
+    }
+}

--- a/backend/src/main/resources/templates/ResumeRejectEmail.html
+++ b/backend/src/main/resources/templates/ResumeRejectEmail.html
@@ -5,10 +5,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Title</title>
+    <style>
+        .info-mail table, .info-mail td, .info-mail th{border: 0 !important; text-align: start}
+    </style>
 </head>
 
 <body>
-<div>
+<div class="info-mail">
     <div class="aHl"></div>
     <div id=":i5" tabindex="-1"></div>
     <div id=":ph" class="ii gt" jslog="20277; u014N:xr6bB; 1:WyIjdGhyZWFkLWY6MTgwOTMxODMzNTg0NjQwODI0OSJd;">
@@ -34,22 +37,17 @@
                                 <td style="background-color: #ffffff; border-radius: 16px; padding: 20px;
                                                 min-height: 200px; border: 1px solid #eeeeee; margin-bottom: 20px; width: 100%;">
                                     <div style="width: 100%; min-height: 200px; font-family: Pretendard, sans-serif, Helvetica, Arial;
-                                                    white-space: pre-wrap; line-height: 1.5em; overflow: hidden;">
+                                                    white-space: pre-wrap; line-height: 0.7em; overflow: hidden;">
                                         <p>안녕하세요, ${ name }님. ${ companyName } 채용담당자입니다.</p>
                                         <p>${ companyName } ${ announcementTitle } 공고에 관심을 가지고 지원해주셔서 감사합니다.</p>
                                         <p>안타깝게도 이후 채용 전형에서는 ${ name }님을 모실 수 없게 되었습니다.</p>
-                                        <p>개별 지원자의 역량과 경험에 대해 최선의 검토를 진행하였으나 제한된 선발 인원으로 인해 모든 지원자께 합격 소식을 전해드리지 못하게 되었습니다.</p>
-                                        <p>비록 이번 채용 모집에서 당사와는 연이 닿지 않았지만 지원자님의 앞날에 늘 건강한 삶과 행복한 일만이 가득하기를 진심으로 바라겠습니다.</p>
+                                        <p>개별 지원자의 역량과 경험에 대해 최선의 검토를 진행하였으나, 제한된 선발 인원으로 인해</p>
+                                        <p>모든 지원자께 합격 소식을 전해드리지 못하게 되었습니다.</p>
+                                        <p>비록 이번 채용 모집에서 당사와는 연이 닿지 않았지만</p>
+                                        <p>지원자님의 앞날에 늘 건강한 삶과 행복한 일만이 가득하기를 진심으로 바라겠습니다.</p>
                                         <p>감사합니다.</p>
                                         <p>${ companyName } 드림</p>
                                     </div>
-                                </td>
-                            </tr>
-                            <!-- 발신 안내 -->
-                            <tr>
-                                <td style="margin-top: 40px; font-size: 14px; color: #212121;" align="center">
-                                    <p>본 메일은 발신전용이므로 회신이 되지 않습니다.</p>
-                                    <p><br></p><p><br></p>
                                 </td>
                             </tr>
                             </tbody>


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #29 
closed #30 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
채용담당자는 각 채용 프로세스 결과를 이메일로 전송 및 알람으로 등록할 수 있습니다.

지원자는 해당 이메일을 템플릿을 통해서 제공받고, 도메인 내 알림페이지에서도 확인할 수 있습니다.
<br>

## ✅ 주요 작업 부분
- 채용 프로세스 결과 템플릿 추가
- 채용 프로세스 결과(알람) 조회 로직 수정
- 화상면접방 일괄 생성 동적 스케줄링 적용
- 이메일 전송을 위한 dto 생성
- 알람 등록 로직 수정
<br>
