### PR TITLE
[#407][Refactor] 채용담당자 페이지 사이드바 중복 메뉴 제거 및 각 페이지 테이블 여백 통일

### DIFF
--- a/frontend/src/components/recruiter/MainSideBarComponent.vue
+++ b/frontend/src/components/recruiter/MainSideBarComponent.vue
@@ -57,9 +57,6 @@ const goAndReload = (path) => {
       <li @click="goAndReload('/recruiter/mypage')">
         마이페이지
       </li>
-      <li @click="goAndReload('/recruiter/interview-evaluate/result')">
-          면접 평가
-      </li>
     </ul>
   </div>
 </template>

--- a/frontend/src/components/seeker/SeekerHeaderComponent.vue
+++ b/frontend/src/components/seeker/SeekerHeaderComponent.vue
@@ -16,7 +16,7 @@
         <img class="header-logo" src="../../assets/img/irs_white.png">
       </a>
       <div class="header-right">
-        <a href="/recruiter">채용 관리</a>
+        <a href="/recruiter/announce">채용 관리</a>
         <a >{{ displayName }}</a>
         <a @click="handleLogout" class="logout-btn">로그아웃</a>
       </div>

--- a/frontend/src/pages/recruiter/interview-evaluate/InterviewEvaluateFormPage.vue
+++ b/frontend/src/pages/recruiter/interview-evaluate/InterviewEvaluateFormPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <MainHeaderComponent></MainHeaderComponent>
-    <div class="wrapper">
+    <div class="">
       <MainSideBarComponent></MainSideBarComponent>
       <div class="container">
         <InterviewEvaluateFormMain
@@ -47,15 +47,5 @@ const loadAnnouncementList = async (btnNum) => {
   margin: 0 auto;
 }
 
-.container {
-  width: 80%;
-  flex: 1;
-  margin: 0 auto;
-  margin-left: 200px;
-  padding: 150px 0;
-  display: flex;
-  flex-direction: column;
-  box-sizing: border-box;
-}
 </style>
   

--- a/frontend/src/pages/recruiter/interview-evaluate/InterviewEvaluateResultPage.vue
+++ b/frontend/src/pages/recruiter/interview-evaluate/InterviewEvaluateResultPage.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
       <MainHeaderComponent></MainHeaderComponent>
-      <div class="wrapper">
+      <div class="">
         <MainSideBarComponent></MainSideBarComponent>
         <div class="container">
           <div id="content">


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
#407 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
채용담당자 페이지 사이드바 중복 메뉴 삭제했습니다.
각 페이지 좌우 여백 통일시켰습니다.(면접 평가, 면접 평가표 페이지)
<br>

## ✅ 주요 작업 부분
채용담당자 사이드바
- 제일 하단 면접 평가 메뉴 삭제

각 페이지 여백
- 면접 평가 페이지 여백 조절
- 면접 평가표 페이지 여백 조절

<br>
