### PR TITLE
[#447][Fix] 지원자 통합지원서 등록 여부 조회 삭제

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/controller/ResumeController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/controller/ResumeController.java
@@ -109,15 +109,6 @@ public class ResumeController {
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.RESUME_READ_SUCCESS, response));
     }
 
-    // (지원자) 통합지원서 등록 여부 조회
-    @GetMapping("/read/integrated-info")
-    public ResponseEntity<BaseResponse<ResumeReadIntegratedInfoRes>> readIntegratedInfo(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
-
-        ResumeReadIntegratedInfoRes response = resumeService.readIntegratedInfo(customUserDetails);
-        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.RESUME_READ_SUCCESS, response));
-    }
-
     // (지원자) 마이페이지 -> 통합 지원서 조회
     @GetMapping("/read/integrated")
     public ResponseEntity<BaseResponse<ResumeReadRes>> readIntegrated(

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/service/ResumeService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/service/ResumeService.java
@@ -751,27 +751,6 @@ public class ResumeService {
 
     }
 
-    public ResumeReadIntegratedInfoRes readIntegratedInfo(CustomUserDetails customUserDetails) throws BaseException {
-        Long seekerIdx = customUserDetails.getIdx();
-        // 지원자 테이블 조회
-        Optional<Seeker> resultSeeker = seekerRepository.findBySeekerIdx(seekerIdx);
-        if(resultSeeker.isPresent()) {
-            // 지원정보 테이블 조회 (통합지원서 등록 여부 조회)
-            Optional<ResumeInfo> resultResumeInfo = resumeInfoRepository.findBySeekerIdxAndIntegrated(seekerIdx, true);
-            if(resultResumeInfo.isPresent()) {
-                return ResumeReadIntegratedInfoRes.builder()
-                        .integrated(true)
-                        .build();
-            } else {
-                return ResumeReadIntegratedInfoRes.builder()
-                        .integrated(false)
-                        .build();
-            }
-        } else {
-            throw new BaseException(BaseResponseMessage.RESUME_REGISTER_FAIL_NOT_FOUND_SEEKER);
-        }
-    }
-
     @Transactional
     public ResumeReadIntegratedRes readIntegrated(CustomUserDetails customUserDetails) throws BaseException {
         Long seekerIdx = customUserDetails.getIdx();

--- a/backend/src/main/java/com/sabujaks/irs/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/config/SecurityConfig.java
@@ -72,7 +72,6 @@ public class SecurityConfig {
                                 .requestMatchers("/api/resume/read").hasAnyAuthority("ROLE_SEEKER", "ROLE_RECRUITER")
                                 .requestMatchers("/api/resume/read/submit-info").hasAuthority("ROLE_SEEKER")
                                 .requestMatchers("/api/resume/read/integrated").hasAuthority("ROLE_SEEKER")
-                                .requestMatchers("/api/resume/read/integrated-info").hasAuthority("ROLE_SEEKER")
                                 .requestMatchers("/api/resume/read-all").hasAuthority("ROLE_SEEKER")
                                 .requestMatchers("/api/resume/recruiter/read-all").hasAuthority("ROLE_RECRUITER")
                                 .requestMatchers("/api/resume/update/docPassed/{resumeIdx}").hasAuthority("ROLE_RECRUITER")


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed: #447 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
지원자가 통합지원서 등록 페이지 진입 시 통합지원서 등록 여부를 조회하여 등록 페이지를 보여주거나 조회 페이지를 보여주기 위해 구현했는데 통합지원서 상세 조회로 대체 가능해서 삭제
<br>

## ✅ 주요 작업 부분
- [x] 통합지원서 등록 여부 조회 삭제

<br>