### PR TITLE
[#413][Refactor] 채용담당자와 지원자 공고 관련 페이지 개선

### DIFF
--- a/frontend/src/pages/recruiter/announce/AnnounceRegisterStep1Page.vue
+++ b/frontend/src/pages/recruiter/announce/AnnounceRegisterStep1Page.vue
@@ -300,16 +300,31 @@ export default {
     // 5. 채용절차 폼 관련 *************************************************************************************
 
     const selectedPeriod = ref('');
-    const activeProcessSteps = ref([]);
+    // const activeProcessSteps = ref([]);
+    const processSteps = ref(['서류전형', '면접전형 > 1차', '면접전형 > 2차', '최종합격']); // 전체 전형 절차 목록
+    const activeProcessSteps = ref([]); // 활성화된 전형 절차 목록
     const times = ['07시', '08시', '09시', '10시', '11시', '12시', '13시', '14시', '15시', '16시', '17시', '18시', '19시', '20시', '21시', '22시', '23시', '24시'];
 
-    const processSteps = computed(() => {
-      const steps = ['서류전형', '면접전형 > 1차', '최종합격'];
-      if (announcementStore.formData.interviewCount === '2') {
-        steps.splice(2, 0, '면접전형 > 2차');
+    // const processSteps = computed(() => {
+    //   const steps = ['서류전형', '면접전형 > 1차', '최종합격'];
+    //   if (announcementStore.formData.interviewCount === '2') {
+    //     steps.splice(2, 0, '면접전형 > 2차');
+    //   }
+    //   return steps;
+    // });
+
+    // 면접 횟수가 변경되면 전형 절차 자동 설정
+    const updateProcessSteps = () => {
+      const interviewCount = announcementStore.formData.interviewCount;
+
+      if (interviewCount === '1') {
+        activeProcessSteps.value = ['서류전형', '면접전형 > 1차', '최종합격'];
+      } else if (interviewCount === '2') {
+        activeProcessSteps.value = ['서류전형', '면접전형 > 1차', '면접전형 > 2차', '최종합격'];
+      } else {
+        activeProcessSteps.value = []; // 초기화
       }
-      return steps;
-    });
+    };
 
     // 1개월2개월 버튼클릭시 마감일 자동설정 함수
     const setActiveButton = (period) => {
@@ -333,15 +348,15 @@ export default {
     };
 
     // 전형절차 버튼클릭으로 해당 단계 활성화, 비활성화
-    const toggleProcessStep = (step) => {
-      if (activeProcessSteps.value.includes(step)) {
-        activeProcessSteps.value = activeProcessSteps.value.filter(s => s !== step);
-      } else {
-        activeProcessSteps.value.push(step);
-      }
-    };
+    // const toggleProcessStep = (step) => {
+    //   if (activeProcessSteps.value.includes(step)) {
+    //     activeProcessSteps.value = activeProcessSteps.value.filter(s => s !== step);
+    //   } else {
+    //     activeProcessSteps.value.push(step);
+    //   }
+    // };
 
-    // 전형절차 문자열 변환
+    // 활성화된 전형 절차를 문자열로 변환하여 히든 인풋에 반영
     const formattedProcessSteps = computed(() => activeProcessSteps.value.join(', '));
 
     // 날짜형식변환
@@ -461,8 +476,9 @@ export default {
       processSteps,
       activeProcessSteps,
       formattedProcessSteps,
+      updateProcessSteps,
       setActiveButton,
-      toggleProcessStep,
+      // toggleProcessStep,
 
       showErrorModal,
       alreadyFun,
@@ -495,22 +511,28 @@ export default {
               </div>
             </div>
           </div>
-          <p>이미지 업로드는 *필수*값을 꼭 입력해 주시고, 템플릿 작성은 모든 값을 입력해 주세요.</p>
+          <p style="font-size: large;">이미지 업로드 양식 - 이미지를 업로드 하고 템플릿 작성 양식으로 이동하여 *필수*값을 꼭 입력한 후 등록해 주세요. <br>
+            템플릿 작성 양식 - 템플릿의 정보를 모두 작성 후 등록해 주세요. </p>
         </div>
 
         <hr style="border: 0.5px solid #abadb8; margin: 30px 0;">
 
         <!-- 이미지 업로드 섹션 -->
-        <div v-if="isImageUpload" id="imageUpload" style="text-align: left; background-color: #f5f8ff;">
+        <div v-if="isImageUpload" id="imageUpload" style="text-align: left; background-color: #f1f1f1;">
           <h3>이미지 업로드</h3>
           <div style="text-align: left;">
-            <input type="file" @change="previewImage" accept="image/*" />
+            <!-- 커스텀 파일 업로드 버튼 -->
+            <label for="fileInput" class="custom-file-upload"
+              style="background-color: #212b36; color: #fff; padding: 10px 10px 10px 35px; border-radius: 5px; cursor: pointer; display: inline-block;">
+              파일 선택
+            </label>
+            <input type="file" id="fileInput" @change="previewImage" accept="image/*" style="display: none;" />
             <!-- <p v-if="fileName">{{ fileName }}</p> -->
             <div id="imagePreviewContainer"
               style="width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; flex-direction: column; background-color: #fff;">
               <!-- 이미지 초기화 버튼 -->
               <button @click="resetImage" v-if="imageUrl"
-                style="margin-top: 10px; border: 1px solid #abadb8; border-radius: 2px;">이미지 초기화</button>
+                style="margin: 10px 0; padding: 10px 10px; border: 1px solid #abadb8; border-radius: 5px; background-color: white;">이미지 초기화</button>
               <img v-if="imageUrl" :src="imageUrl" id="imagePreview"
                 style="width: 100%; height: 100%; object-fit: contain;">
               <p v-else id="noImageText" style="color: #777;">하나의 파일로 된 이미지를 선택하세요.</p>
@@ -622,21 +644,22 @@ export default {
               <div v-if="fields.department" class="required-parents-div">
                 <label></label>
                 <div class="required-child-div">
-                  <textarea type="text" style="width: 800px; font-size: 16px;" @input="autoResize($event)" v-model="announcementStore.formData.department" placeholder="근무 부서 입력"
-                    name="department"></textarea>
+                  <textarea type="text" style="width: 800px; font-size: 16px;" @input="autoResize($event)"
+                    v-model="announcementStore.formData.department" placeholder="근무 부서 입력" name="department"></textarea>
                 </div>
               </div>
               <div v-if="fields.position" class="required-parents-div">
                 <label></label>
                 <div class="required-child-div">
-                  <textarea type="text" style="width: 800px; font-size: 16px;" @input="autoResize($event)" v-model="announcementStore.formData.position" placeholder="직급 직책 입력"
-                    name="position"></textarea>
+                  <textarea type="text" style="width: 800px; font-size: 16px;" @input="autoResize($event)"
+                    v-model="announcementStore.formData.position" placeholder="직급 직책 입력" name="position"></textarea>
                 </div>
               </div>
               <div v-if="fields.requirement" class="required-parents-div">
                 <label></label>
                 <div class="required-child-div">
-                  <textarea type="text" style="width: 800px; font-size: 16px;" @input="autoResize($event)" v-model="announcementStore.formData.requirement" placeholder="필수/우대조건 입력"
+                  <textarea type="text" style="width: 800px; font-size: 16px;" @input="autoResize($event)"
+                    v-model="announcementStore.formData.requirement" placeholder="필수/우대조건 입력"
                     name="requirement"></textarea>
                 </div>
               </div>
@@ -735,10 +758,9 @@ export default {
               <div v-if="fields2.workTime" class="required-parents-div">
                 <label>출퇴근 시간</label>
                 <div class="required-child-div">
-                  <select v-model="announcementStore.formData.startTime" style="width: 200px; padding: 10px;">
+                  <select v-model="announcementStore.formData.startTime" style="width: 200px; padding: 10px; margin-right: 15px;">
                     <option v-for="time in timeOptions" :key="time" :value="time">{{ time }}</option>
                   </select>
-                  ~
                   <select v-model="announcementStore.formData.endTime" style="width: 200px; padding: 10px;">
                     <option v-for="time in timeOptions" :key="time" :value="time">{{ time }}</option>
                   </select>
@@ -842,19 +864,18 @@ export default {
             <!-- 지원 접수 기간 -->
             <div class="required-parents-div">
               <label class="required required2">지원 접수 기간</label>
-              <div class="required-child-div">
+              <div class="required-child-div" style="display: flex; justify-content: left; flex-direction: column; align-items:start">
                 <div class="btn-group" style="margin-bottom: 20px;">
                   <button :class="{ active: selectedPeriod === '1개월' }" @click="setActiveButton('1개월')">1개월</button>
                   <button :class="{ active: selectedPeriod === '2개월' }" @click="setActiveButton('2개월')">2개월</button>
                 </div>
                 <div>
                   <input type="date" v-model="announcementStore.formData.startDate" />
-                  <select v-model="announcementStore.formData.startTimeRegi">
+                  <select style="margin-right: 15px;" v-model="announcementStore.formData.startTimeRegi">
                     <option v-for="time in times" :key="time" :value="time">{{ time }}</option>
                   </select>
-                  ~
                   <input type="date" v-model="announcementStore.formData.endDate" />
-                  <select v-model="announcementStore.formData.endTimeRegi">
+                  <select style="margin-right: 15px;" v-model="announcementStore.formData.endTimeRegi">
                     <option v-for="time in times" :key="time" :value="time">{{ time }}</option>
                   </select>
                   <select v-model="announcementStore.formData.recruitmentType">
@@ -869,7 +890,7 @@ export default {
             <div class="required-parents-div">
               <label class="required required2">면접 횟수</label>
               <div class="required-child-div">
-                <select v-model="announcementStore.formData.interviewCount">
+                <select v-model="announcementStore.formData.interviewCount" @change="updateProcessSteps">
                   <option value="선택해 주세요">선택해 주세요</option>
                   <option value="1">1</option>
                   <option value="2">2</option>
@@ -882,12 +903,12 @@ export default {
               <label>전형절차</label>
               <div class="required-child-div">
                 <div class="btn-group">
+                  <!-- @click="toggleProcessStep(step)" -->
                   <button v-for="step in processSteps" :key="step"
-                    :class="{ active: activeProcessSteps.includes(step) }" @click="toggleProcessStep(step)">
+                    :class="{ active: activeProcessSteps.includes(step) }">
                     {{ step }}
                   </button>
                 </div>
-                <p> 면접 횟수와 맞춰 클릭 해 주세요.</p>
               </div>
             </div>
 
@@ -915,6 +936,7 @@ export default {
 
         <!-- 다음 스텝 버튼 -->
         <div class="submit-section">
+          <p style="font-size: large;">이미지 업로드 시, 템플릿 작성 양식으로 이동하여 *필수*값을 꼭 입력한 후 등록해 주세요.</p>
           <button @click="alreadyFun" id="buildFormBtn">공고 등록 후 지원서 폼 조립하기</button>
         </div>
       </div>
@@ -939,6 +961,17 @@ export default {
 
 
 /* 추가된 css */
+input[type="number"] {
+  /* width: calc(100% - 40px); */
+  padding: 20px 5px;
+  width: 200px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #fff;
+  background-size: 15px;
+  font-size: 16px;
+}
+
 #imageUpload {
   background-color: #f5f8ff;
   border: 1px solid #ccc;
@@ -1192,8 +1225,8 @@ button.inactive {
 }
 
 .benefits-box {
-  border: 1px solid #f5f8ff;
-  background-color: #f5f8ff;
+  /* border: 1px solid #f5f8ff; */
+  /* background-color: #f5f8ff; */
   padding: 20px;
   border-radius: 5px;
   margin-bottom: 50px;
@@ -1228,7 +1261,8 @@ button.inactive {
   padding: 5px 10px;
   border-radius: 15px;
   margin: 5px;
-  background-color: #eaedf4;
+  background-color: #212b36;
+  color: white;
 }
 
 .subcategory-label {

--- a/frontend/src/pages/recruiter/announce/AnnounceRegisterStep2Page.vue
+++ b/frontend/src/pages/recruiter/announce/AnnounceRegisterStep2Page.vue
@@ -4,7 +4,7 @@
         <MainSideBarComponent></MainSideBarComponent>
         <div id="content">
             <div style="display: flex; justify-content: space-between;">
-                <h2>[{{ router.params.title }}] 공고<br>지원서 폼 조립</h2>
+                <h2>[{{ route.params.title }}] 공고<br>지원서 폼 조립</h2>
                 <!-- 저장 버튼 -->
                 <button @click="saveForm" class="save-button">폼 저장</button>
             </div>
@@ -28,7 +28,7 @@
                     <div v-for="(section, index) in coverLetterSections" :key="index" class="cover-letter-item"
                         style="margin-top: 15px;">
                         <textarea type="text" v-model="section.title" @input="autoResize($event)" style="font-size: 18px; height: 40px; width: 600px;" placeholder="문항입력" ></textarea>
-                        <input type="number" v-model="section.characterLimit" style="font-size: 18px; height: 20px; width: 60px;"
+                        <input type="number" v-model="section.characterLimit" style="font-size: 18px; height: 40px; width: 100px;"
                             placeholder="글자 수 제한" />
                         <button style="padding: 10px 10px; border-radius: 5px; height: 40px; width: 60px;"
                             @click="removeCoverLetterSection(index)">삭제</button>
@@ -45,11 +45,12 @@ import MainSideBarComponent from "@/components/recruiter/MainSideBarComponent.vu
 // import { UseAnnouncementStore } from '@/stores/UseAnnouncementStore';
 import { UseCustomFormStore } from '@/stores/UseCustomFormStore';
 import { ref } from "vue";
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
 // const announcementStore = UseAnnouncementStore();s
 const customFormStore = UseCustomFormStore();
-const router = useRoute();
+const route = useRoute();
+const router = useRouter();
 
 // 폼 종류 리스트
 const formItems = ref([
@@ -109,7 +110,7 @@ const autoResize = (event) => {
 
 // 폼 저장 함수 호출
 const saveForm = () => {
-    customFormStore.saveForm(router.params.announcementIdx, selectedForms.value, coverLetterSections.value);
+    customFormStore.saveForm(route.params.announcementIdx, selectedForms.value, coverLetterSections.value, router);
 };
 </script>
 
@@ -129,7 +130,7 @@ const saveForm = () => {
     /* flex: 1; */
     margin-left: 200px;
     /* 사이드바 너비만큼 왼쪽 여백 추가 */
-    padding: 150px 0;
+    padding: 0 0 150px 0;
     display: flex;
     /* flex-direction: column; */
     box-sizing: border-box;

--- a/frontend/src/pages/seeker/announce/AnnounceReadAllPage.vue
+++ b/frontend/src/pages/seeker/announce/AnnounceReadAllPage.vue
@@ -108,7 +108,7 @@
             <ul data-pageno="1" data-count="20" data-totalcount="3641" data-totalcounttext="3,641">
               <li class="option" v-for="(announcement) in announcementStore.announcements2"
                   :key="announcement.announcementIdx" @click="goToDetailPage(announcement.announcementIdx)">
-                <a href="" class="listCell" target="_blank" data-gno="45672569">
+                <a href="" class="listCell" data-gno="45672569">
                   <div class="rLogo">
                     <img src="@/assets/img/announce/no-background.jpg" alt="㈜365위더스">
                   </div>

--- a/frontend/src/stores/UseAnnouncementStore.js
+++ b/frontend/src/stores/UseAnnouncementStore.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import axios from 'axios';
 import { backend } from '@/const';
 import { toRaw } from 'vue';
+import { useToast } from 'vue-toastification';
 
 export const UseAnnouncementStore = defineStore('announcement', {
     state: () => ({
@@ -295,7 +296,11 @@ export const UseAnnouncementStore = defineStore('announcement', {
                 console.log("응답" + response.data.result);
 
                 if (response.status === 200) {
-                    alert('데이터가 성공적으로 저장되었습니다.');
+                    // alert('데이터가 성공적으로 저장되었습니다.');
+                    console.log(response.data);
+
+                    const toast = useToast();
+                    toast.success("공고가 등록되었습니다. 지원서 폼 조립 페이지로 이동합니다.");
 
                     // announcementIdx가 제대로 전달되는지 확인
                     // console.log(response.data.result.announcementIdx);
@@ -311,7 +316,9 @@ export const UseAnnouncementStore = defineStore('announcement', {
                 }
             } catch (error) {
                 console.error('데이터 저장 실패:', error);
-                alert('데이터 저장 중 오류가 발생했습니다.' + error.response.data.message);
+                // alert('데이터 저장 중 오류가 발생했습니다.' + error.response.data.message);
+                const toast = useToast();
+                toast.error(error.response.data.message);
             }
         },
 

--- a/frontend/src/stores/UseCustomFormStore.js
+++ b/frontend/src/stores/UseCustomFormStore.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import axios from 'axios';
 import { backend } from '@/const';
+import { useToast } from 'vue-toastification';
 
 export const UseCustomFormStore = defineStore('customform', {
     state: () => ({
@@ -8,7 +9,7 @@ export const UseCustomFormStore = defineStore('customform', {
     }),
     actions: {
         // 지원서 폼 저장 로직
-        async saveForm(announcementIdx, selectedForms, coverLetterSections) {
+        async saveForm(announcementIdx, selectedForms, coverLetterSections, router) {
             try {
                 const titleList = coverLetterSections.map((section) => section.title);
                 const chatLimitList = coverLetterSections.map((section) => section.characterLimit);
@@ -34,14 +35,22 @@ export const UseCustomFormStore = defineStore('customform', {
                 console.log("응답" + response.data.result);
 
                 if (response.status === 200) {
-                    alert('폼 저장이 완료되었습니다. 공고 메뉴로 이동해 주세요.');
+                    const toast = useToast();
+                    toast.success('폼 저장이 완료되었습니다. 공고 메뉴로 이동합니다.');
 
                     // router를 통해 특정 경로로 리다이렉트
                     // router.push('/recruiter/mypage');
+
+                    // 알림이 끝난 후 이동 (2초 후)
+                    setTimeout(() => {
+                        router.push('/recruiter/announce');
+                    }, 2000); // 2000ms = 2초 (알림 지속 시간에 맞추어 조정)
                 }
             } catch (error) {
                 console.error('폼 저장 실패:', error);
-                alert('폼 저장에 실패하였습니다. ' + error);
+
+                const toast = useToast();
+                toast.error('폼 저장에 실패하였습니다. ' + error.response.data.message);
             }
 
         }


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
#413
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
두 유저 전체 공고 관련 페이지 개선
<br>

## ✅ 주요 작업 부분
이미지 업로드 버튼 디자인 수정
이미지 업로드 배경색 수정
이미지 업로드일때 카테고리 db에 들어가게 필수 처리 추가
공고 등록 시 복리후생 조회 디자인 변경
지원 접수 기간 날짜 부분 한 칸 밑으로 내리기
면접 횟수 -> 전형절차 자동으로 들어가게 수정
지원서 폼 조립 상단 여백 조정
지원서 폼 조립 후 /recruiter/announce 페이지로 리다이렉트
지원자 메인페이지(목록 조회) : 메인에서 공고 상세 들어갈 때 새창 뜨는 부분 수정 (새창 뜨면서 헤더가 로그아웃된 것 처럼 변경됨 -> a 태그에 타겟 삭제해서 해결)
<br>