### PR TITLE
[#462][Refactor] 채용담당자 인터뷰 일정 조율 및 일정 조율 관리 페이지 개선

### DIFF
--- a/frontend/src/components/recruiter/InterviewScheduleList.vue
+++ b/frontend/src/components/recruiter/InterviewScheduleList.vue
@@ -52,12 +52,6 @@ const startNumberForPage = computed(() => {
   return isLoading.value ? '-' : props.totalInterviewSchedules - (currentPage.value - 1) * postsPerPage;
 });
 
-// 현재 페이지에 맞는 면접 일정 slice
-const paginatedInterviewSchedules = computed(() => {
-  const start = (currentPage.value - 1) * postsPerPage;
-  return props.interviewSchedules.slice(start, start + postsPerPage);
-});
-
 const handleRowClick = (type) => {
   emit('openModal', type);
 }
@@ -84,7 +78,6 @@ const getUniqueSeekers = (seekerList) => {
 }
 
 const handleScheduleClick = (schedule) => {
-  console.log(schedule);
   router.push(`/recruiter/interview-schedule/detail/${schedule.idx}`);
 }
 
@@ -115,7 +108,7 @@ const handleCreateAllVideoInterview = () => {
         <th>참가자</th>
         <th>면접방생성</th>
       </tr>
-      <tr v-for="(schedule, index) in paginatedInterviewSchedules" :key="schedule.uuid"
+      <tr v-for="(schedule, index) in props.interviewSchedules" :key="schedule.uuid"
           @click="handleScheduleClick(schedule)">
         <td>{{ startNumberForPage - index }}</td>
         <td>{{ formatDate(schedule.interviewDate) }}</td>
@@ -129,7 +122,8 @@ const handleCreateAllVideoInterview = () => {
           </ul>
         </td>
         <td>
-          <button class="create-video-interview" @click="createVideoInterview(schedule.uuid, schedule, $event)">방 생성</button>
+          <button class="create-video-interview" @click="createVideoInterview(schedule.uuid, schedule, $event)">방 생성
+          </button>
         </td>
       </tr>
       </tbody>

--- a/frontend/src/components/recruiter/InterviewScheduleMain.vue
+++ b/frontend/src/components/recruiter/InterviewScheduleMain.vue
@@ -51,10 +51,6 @@ const handlePageClick = async (pageNumber) => {
   isLoading.value = false; // 로딩 종료
 };
 
-// const startNumberForPage = computed(() => {
-//   return props.totalAnnouncements - (currentPage.value - 1) * postsPerPage;
-// });
-
 // const announceIdx = ref(0);
 const interviewScheduleStore = UseInterviewScheduleStore(); // Store 인스턴스
 const handleRowClick = (announcementIdx, announcementUuid) => {
@@ -63,9 +59,17 @@ const handleRowClick = (announcementIdx, announcementUuid) => {
   interviewScheduleStore.setAnnouncementUuid(announcementUuid);
   interviewScheduleStore.setCareerBase(props.careerBase);
 
-  router.push({
-    path: "/recruiter/interview-schedule/list",
-  });
+  console.log(props.title);
+  if (props.title === "전체") {
+    // emit('interviewScheduleList', props.announcementIdx, props.announcementUuid);
+    router.push({
+      path: "/recruiter/interview-schedule/reschedule/list",
+    });
+  } else {
+    router.push({
+      path: "/recruiter/interview-schedule/list",
+    });
+  }
 }
 
 const formatDate = (datetime) => {

--- a/frontend/src/components/recruiter/ReScheduleList.vue
+++ b/frontend/src/components/recruiter/ReScheduleList.vue
@@ -1,5 +1,7 @@
 <script setup>
 import {computed, defineEmits, defineProps, ref} from 'vue';
+import router from "@/router";
+import {UseInterviewScheduleStore} from "@/stores/UseInterviewScheduleStore";
 
 // props를 정의합니다.
 const props = defineProps({
@@ -27,6 +29,7 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['interviewScheduleInfo']);
+const interviewScheduleStore = UseInterviewScheduleStore();
 
 const postsPerPage = 10; // 페이지당 게시글 수
 const totalPages = computed(() => {
@@ -52,7 +55,14 @@ const paginatedReSchedules = computed(() => {
 });
 
 const handleRowClick = (schedule) => {
-  emit('interviewScheduleInfo', schedule, props.announcementIdx, props.announcementUuid);
+  // emit('interviewScheduleInfo', schedule, props.announcementIdx, props.announcementUuid);
+  interviewScheduleStore.setScheduleInfo(schedule);
+
+  console.log(interviewScheduleStore.scheduleInfo);
+
+  router.push({
+    path: "/recruiter/interview-schedule/reschedule/detail/" + schedule.idx,
+  })
 }
 </script>
 

--- a/frontend/src/pages/recruiter/interview-schedule/InterviewScheduleMainNewPage.vue
+++ b/frontend/src/pages/recruiter/interview-schedule/InterviewScheduleMainNewPage.vue
@@ -23,6 +23,7 @@ onMounted(async () => {
 
 const loadAnnouncementList = async (btnNum) => {
   announcements.value = await interviewScheduleStore.readAllAnnouncement(careerBase.value, btnNum);
+  console.log(announcements.value);
 }
 
 </script>

--- a/frontend/src/pages/recruiter/interview-schedule/ReScheduleDetailPage.vue
+++ b/frontend/src/pages/recruiter/interview-schedule/ReScheduleDetailPage.vue
@@ -1,0 +1,81 @@
+<script setup>
+
+import ReScheduleDetail from "@/components/recruiter/ReScheduleDetail.vue";
+import MainSideBarComponent from "@/components/recruiter/MainSideBarComponent.vue";
+import MainHeaderComponent from "@/components/recruiter/MainHeaderComponent.vue";
+import { onMounted, ref, watch } from "vue";
+import { UseInterviewScheduleStore } from "@/stores/UseInterviewScheduleStore";
+import {useRouter} from "vue-router";
+import { useToast } from "vue-toastification";
+
+const interviewSchedules = ref(null);  // 초기값을 null로 설정하여 로딩 상태를 구분
+const interviewScheduleDetail = ref(null);  // 초기값을 null로 설정
+const announcementIdxInfo = ref(0);
+const announcementUuidInfo = ref("");
+
+const router = useRouter();
+const toast = useToast();
+const interviewScheduleStore = UseInterviewScheduleStore();
+
+onMounted(async () => {
+  // 데이터 로딩 중
+  announcementIdxInfo.value = interviewScheduleStore.announcementIdx || 0;
+  announcementUuidInfo.value = interviewScheduleStore.announcementUuid || "";
+
+  // scheduleInfo가 undefined일 가능성이 있기 때문에 기본값 설정
+  interviewSchedules.value = interviewScheduleStore.scheduleInfo || {};
+  console.log("Loaded interviewSchedules:", interviewSchedules.value);
+
+  if (interviewSchedules.value.interviewScheduleRes) {
+    interviewScheduleDetail.value = await interviewScheduleStore.readInterviewSchedule(interviewSchedules.value.interviewScheduleRes.idx);
+    console.log("Loaded interviewScheduleDetail:", interviewScheduleDetail.value);
+  }
+});
+
+// 데이터 변화 감지
+watch(interviewSchedules, (newVal) => {
+  console.log("Updated interviewSchedules:", newVal);
+});
+
+const updateData = async (updateData, updateInfo) => {
+  const updateResult = await interviewScheduleStore.updateInterviewSchedule(updateInfo);
+  const createResult = await interviewScheduleStore.createInterviewSchedule(updateData);
+
+  if (createResult && updateResult) {
+    toast.success(`일정 조율 확정에 성공했습니다.`)
+
+    await router.push({
+      path: "/recruiter/interview-schedule/reschedule",
+    })
+  }
+}
+
+</script>
+
+<template>
+  <MainHeaderComponent/>
+  <div class="container">
+    <MainSideBarComponent/>
+
+    <!-- 데이터가 준비되었을 때만 ReScheduleDetail 렌더링 -->
+    <ReScheduleDetail
+        v-if="interviewSchedules && interviewScheduleDetail"
+        @updateData="updateData"
+        :title="'면접일정 세부내역'"
+        :reScheduleInfo="interviewSchedules"
+        :interviewScheduleDetail="interviewScheduleDetail"
+        :announcementIdx="announcementIdxInfo"
+        :announcementUuid="announcementUuidInfo">
+    </ReScheduleDetail>
+
+    <!-- 로딩 중일 때의 상태를 표시 -->
+    <div v-else>
+      Loading interview schedule details...
+    </div>
+
+  </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/frontend/src/pages/recruiter/interview-schedule/ReScheduleListPage.vue
+++ b/frontend/src/pages/recruiter/interview-schedule/ReScheduleListPage.vue
@@ -1,0 +1,60 @@
+<script setup>
+
+import MainSideBarComponent from "@/components/recruiter/MainSideBarComponent.vue";
+import ReScheduleList from "@/components/recruiter/ReScheduleList.vue";
+import MainHeaderComponent from "@/components/recruiter/MainHeaderComponent.vue";
+import {onMounted, ref} from "vue";
+import {UseInterviewScheduleStore} from "@/stores/UseInterviewScheduleStore";
+
+const isModalOpen = ref(false);
+const modalTitle = ref('');
+const totalReSchedules = ref(0);
+const reSchedules = ref([]);
+// const isInterviewScheduleList = ref(true);
+// const isReScheduleDetail = ref(true);
+// const careerBase = ref("전체");
+// const reqData = ref({});
+const pageNum = ref(1);
+const announcementIdxInfo = ref(0);
+const announcementUuidInfo = ref("");
+
+
+const interviewScheduleStore = UseInterviewScheduleStore(); // Store 인스턴스
+
+onMounted(async () => {
+  announcementIdxInfo.value = interviewScheduleStore.announcementIdx;
+  announcementUuidInfo.value = interviewScheduleStore.announcementUuid;
+
+  reSchedules.value = await interviewScheduleStore.readAllReSchedule(announcementIdxInfo.value, pageNum.value);
+  totalReSchedules.value = await interviewScheduleStore.getTotalReSchedule(announcementIdxInfo.value);
+})
+
+
+const setModalTitle = (title) => {
+  if (!isModalOpen.value) {  // 모달이 열려있지 않을 때만 실행
+    modalTitle.value = title;
+  }
+}
+
+
+</script>
+
+<template>
+  <MainHeaderComponent/>
+  <div class="container">
+    <MainSideBarComponent/>
+    <ReScheduleList
+        @interviewScheduleInfo="interviewScheduleInfo"
+        :title="'일정 조율 신청 내역'"
+        :titleModal="setModalTitle"
+        :reSchedules="reSchedules"
+        :totalReSchedules="totalReSchedules"
+        :announcementIdx="announcementIdxInfo"
+        :announcementUuid="announcementUuidInfo">
+    </ReScheduleList>
+  </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/frontend/src/pages/recruiter/interview-schedule/ReScheduleMainPage.vue
+++ b/frontend/src/pages/recruiter/interview-schedule/ReScheduleMainPage.vue
@@ -5,92 +5,26 @@ import MainSideBarComponent from '../../../components/recruiter/MainSideBarCompo
 import '@/assets/css/grid.css';
 import {UseInterviewScheduleStore} from '@/stores/UseInterviewScheduleStore';
 import InterviewScheduleMain from "../../../components/recruiter/InterviewScheduleMain.vue";
-import ReScheduleList from "@/components/recruiter/ReScheduleList.vue";
-import ReScheduleDetail from "@/components/recruiter/ReScheduleDetail.vue";
 
 
 const isInterviewScheduleMain = ref(true);
-const isInterviewScheduleList = ref(false);
-const isReScheduleDetail = ref(false);
 
 const interviewScheduleStore = UseInterviewScheduleStore(); // Store 인스턴스
 const careerBase = ref("전체");
-const isModalOpen = ref(false);
-const modalTitle = ref('');
+
 const announcements = ref([]);
 const totalAnnouncements = ref(0);
-const interviewSchedules = ref([]);
-const totalReSchedules = ref(0);
-const announcementIdxInfo = ref(0);
-const announcementUuidInfo = ref("");
-const reSchedules = ref([]);
-const interviewScheduleDetail = ref([]);
 
 
-const reqData = ref({});
 const pageNum = ref(1);
 
 onMounted(async () => {
   announcements.value = await interviewScheduleStore.readAllAnnouncement(careerBase.value, pageNum.value);
   totalAnnouncements.value = await interviewScheduleStore.getTotalAnnouncement(careerBase.value);
-
-  console.log(announcements);
-  console.log(totalAnnouncements.value);
 })
 
 const loadAnnouncementList = async (btnNum) => {
   announcements.value = await interviewScheduleStore.readAllAnnouncement(careerBase.value, btnNum);
-}
-
-const interviewScheduleLists = async (announcementIdx, announcementUuid) => {
-  isInterviewScheduleList.value = true;
-  isInterviewScheduleMain.value = false;
-
-  reqData.value = {
-    careerBase: careerBase.value,
-    announcementIdx: announcementIdx,
-  };
-
-  reSchedules.value = await interviewScheduleStore.readAllReSchedule(reqData.value, pageNum.value);
-  totalReSchedules.value = await interviewScheduleStore.getTotalReSchedule(reqData.value);
-
-  announcementIdxInfo.value = announcementIdx;
-  announcementUuidInfo.value = announcementUuid;
-}
-
-// const announcementUuid = (announcementUuid) => {
-//   announcementUuidInfo.value = announcementUuid;
-// }
-
-const setModalTitle = (title) => {
-  if (!isModalOpen.value) {  // 모달이 열려있지 않을 때만 실행
-    modalTitle.value = title;
-  }
-}
-
-// 모달 열기 함수에서 무한 호출 방지
-const interviewScheduleInfo = async (interviewScheduleInfo, announcementIdx, announcementUuid) => {
-  isInterviewScheduleList.value = false;
-  isReScheduleDetail.value = true;
-
-  interviewSchedules.value = interviewScheduleInfo;
-
-  interviewScheduleDetail.value = await interviewScheduleStore.readInterviewSchedule(interviewScheduleInfo.interviewScheduleRes.idx);
-  announcementIdxInfo.value = announcementIdx;
-  announcementUuidInfo.value = announcementUuid;
-};
-
-const updateData = async (updateData, updateInfo, pageUpdateData) => {
-  const updateResult = await interviewScheduleStore.updateInterviewSchedule(updateInfo);
-  const createResult = await interviewScheduleStore.createInterviewSchedule(updateData);
-
-  if (createResult && updateResult) {
-    alert('성공했습니다!');
-
-    window.scrollTo({top: 0});
-    isReScheduleDetail.value = false;
-    await interviewScheduleLists(pageUpdateData.announcementIdx);
-  }
 }
 </script>
 
@@ -99,7 +33,6 @@ const updateData = async (updateData, updateInfo, pageUpdateData) => {
   <MainHeaderComponent/>
   <div class="container">
     <MainSideBarComponent/>
-    <!-- InterviewScheduleMainNew에서 이벤트를 받아 모달을 제어 -->
     <InterviewScheduleMain
         v-if="isInterviewScheduleMain"
         @interviewScheduleList="interviewScheduleLists"
@@ -108,27 +41,6 @@ const updateData = async (updateData, updateInfo, pageUpdateData) => {
         :announcements="announcements"
         :totalAnnouncements="totalAnnouncements">
     </InterviewScheduleMain>
-
-    <ReScheduleList
-        v-if="isInterviewScheduleList"
-        @interviewScheduleInfo="interviewScheduleInfo"
-        :title="'일정 조율 신청 내역'"
-        :titleModal="setModalTitle"
-        :reSchedules="reSchedules"
-        :totalReSchedules="totalReSchedules"
-        :announcementIdx="announcementIdxInfo"
-        :announcementUuid="announcementUuidInfo">
-    </ReScheduleList>
-
-    <ReScheduleDetail
-        v-if="isReScheduleDetail"
-        @updateData="updateData"
-        :title="'면접일정 세부내역'"
-        :reScheduleInfo="interviewSchedules"
-        :interviewScheduleDetail="interviewScheduleDetail"
-        :announcementIdx="announcementIdxInfo"
-        :announcementUuid="announcementUuidInfo">
-    </ReScheduleDetail>
   </div>
 </template>
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -25,7 +25,7 @@ import AnnounceRegisterStep1Page from "@/pages/recruiter/announce/AnnounceRegist
 import InterviewScheduleMainNewPage from "@/pages/recruiter/interview-schedule/InterviewScheduleMainNewPage.vue";
 import InterviewScheduleMainExpPage from "@/pages/recruiter/interview-schedule/InterviewScheduleMainExpPage.vue";
 import InterviewScheduleMain from '@/components/recruiter/InterviewScheduleMain.vue';
-import ReScheduleMainExp from "@/pages/recruiter/interview-schedule/ReScheduleMainExp.vue";
+import ReScheduleMainPage from "@/pages/recruiter/interview-schedule/ReScheduleMainPage.vue";
 import { UseAuthStore } from "@/stores/UseAuthStore";
 import CompanyInfoPage from "@/pages/recruiter/company/CompanyInfoPage.vue";
 import InterviewEvaluateResultPage from '@/pages/recruiter/interview-evaluate/InterviewEvaluateResultPage.vue';
@@ -33,6 +33,8 @@ import InterveiwEvaluateResultDetailPage from '@/pages/recruiter/interview-evalu
 import InterviewScheduleDetail from "@/pages/recruiter/interview-schedule/InterviewScheduleDetail.vue";
 import InterviewScheduleListPage from "@/pages/recruiter/interview-schedule/InterviewScheduleListPage.vue";
 import InterviewEvaluateFormCreatePage from '@/pages/recruiter/interview-evaluate/InterviewEvaluateFormCreatePage.vue';
+import ReScheduleListPage from "@/pages/recruiter/interview-schedule/ReScheduleListPage.vue";
+import ReScheduleDetailPage from "@/pages/recruiter/interview-schedule/ReScheduleDetailPage.vue";
 
 const requireRecruiterLogin = async (to, from, next) => {
     const authStore = UseAuthStore();
@@ -74,7 +76,9 @@ const router = createRouter({
         { path: '/recruiter/announce/register-step2/:announcementIdx/:title', name: 'AnnouncementCreateStep2', component: AnnounceRegisterStep2Page, beforeEnter: requireRecruiterLogin },
 
         { path: '/recruiter/interview-schedule', component: InterviewScheduleMain, beforeEnter: requireRecruiterLogin },
-        { path: '/recruiter/interview-schedule/reschedule', component: ReScheduleMainExp, beforeEnter: requireRecruiterLogin },
+        { path: '/recruiter/interview-schedule/reschedule', component: ReScheduleMainPage, beforeEnter: requireRecruiterLogin },
+        { path: '/recruiter/interview-schedule/reschedule/list', component: ReScheduleListPage, beforeEnter: requireRecruiterLogin },
+        { path: '/recruiter/interview-schedule/reschedule/detail/:idx', component: ReScheduleDetailPage, beforeEnter: requireRecruiterLogin },
         { path: '/recruiter/interview-schedule/new', component: InterviewScheduleMainNewPage, beforeEnter: requireRecruiterLogin },
         { path: '/recruiter/interview-schedule/exp', component: InterviewScheduleMainExpPage, beforeEnter: requireRecruiterLogin },
         { path: '/recruiter/interview-schedule/list', component: InterviewScheduleListPage, beforeEnter: requireRecruiterLogin },

--- a/frontend/src/stores/UseInterviewScheduleStore.js
+++ b/frontend/src/stores/UseInterviewScheduleStore.js
@@ -8,6 +8,7 @@ export const UseInterviewScheduleStore = defineStore('reservation', {
             announcementIdx: null,
             announcementUuid: "",
             careerBase: "",
+            scheduleInfo: {},
         }
     ),
     actions: {
@@ -19,6 +20,9 @@ export const UseInterviewScheduleStore = defineStore('reservation', {
         },
         setCareerBase(careerBase) {
             this.careerBase = careerBase;
+        },
+        setScheduleInfo(scheduleInfo) {
+            this.scheduleInfo = scheduleInfo;
         },
 
         // 면접 일정 생성
@@ -207,12 +211,10 @@ export const UseInterviewScheduleStore = defineStore('reservation', {
             try{
                 const reScheduleResponse = await axios.get(
                     `${backend}/interview-schedule/read-all/re-schedule?` +
-                    `announcementIdx=${announceIdx.announcementIdx}` +
+                    `announcementIdx=${announceIdx}` +
                     `&pageNum=${pageNum}` ,
                     {withCredentials: true}
                 );
-
-                console.log(reScheduleResponse.data.result);
 
                 return reScheduleResponse.data.result;
             } catch (error) {
@@ -221,17 +223,15 @@ export const UseInterviewScheduleStore = defineStore('reservation', {
             }
         },
 
-        async getTotalReSchedule(reqData) {
+        async getTotalReSchedule(announcementIdx) {
             try{
                 const response = await axios.get(
                     // `api/interview-schedule/create`,
                     `${backend}/interview-schedule/read-all/count/re-schedule?` +
-                    `&announcementIdx=${reqData.announcementIdx}`,
+                    `&announcementIdx=${announcementIdx}`,
                     // 쿠키 포함
                     { withCredentials: true }
                 );
-
-                console.log(response);
 
                 return response.data.result;
             } catch (error) {


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
#462
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
채용담당자 인터뷰 일정 페이지 새로고침 및 redirect시 에러 해결했습니다.
채용담당자 인터뷰 일정 조율 페이지 분리했습니다.
<br>

## ✅ 주요 작업 부분
- 인터뷰 일정 페이지 새로고침 및 redirect시 요구되는 데이터 default 셋팅
- 인터뷰 일정 조율 페이지 메인, 리스트, 상세조회 총 3개로 분리

<br>