### PR TITLE
[#451][Refactor] 공고 등록 및 조회 로직 개선

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/service/AnnouncementService.java
@@ -19,8 +19,10 @@ import com.sabujaks.irs.domain.company.repository.CompanyRepository;
 import com.sabujaks.irs.domain.company.service.CompanyService;
 import com.sabujaks.irs.domain.resume.model.entity.Resume;
 import com.sabujaks.irs.domain.system.model.entity.BaseInfo;
+import com.sabujaks.irs.domain.system.model.response.BaseInfoReadRes;
 import com.sabujaks.irs.domain.system.repository.BaseInfoRepository;
 import com.sabujaks.irs.domain.resume.repository.ResumeRepository;
+import com.sabujaks.irs.domain.system.service.BaseInfoService;
 import com.sabujaks.irs.global.common.exception.BaseException;
 import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
 import com.sabujaks.irs.global.security.CustomUserDetails;
@@ -45,6 +47,7 @@ public class AnnouncementService {
     private final CompanyRepository companyRepository;
     private final ResumeRepository resumeRepository;
     private final CompanyService companyService;
+    private final BaseInfoService baseInfoService;
 
 
     /*******채용담당자 공고 등록 (step1)***********/
@@ -225,6 +228,17 @@ public class AnnouncementService {
             if (resultCompany.isPresent()) {
                 Company company = resultCompany.get();
                 Recruiter resultRecruiter = recruiterRepository.findByRecruiterIdx(company.getRecruiter().getIdx()).get();
+
+                // 카테고리 문자로 변환
+                List<String> addJobCategorys = new ArrayList<>();
+                if(announcement.getJobCategory() != null) {
+                    for(BaseInfoReadRes bir : baseInfoService.getInfo(announcement.getJobCategory())) {
+                        addJobCategorys.add(bir.getGroupName()+" > "+bir.getDescription());
+                    }
+                }
+                String jobCategoryString = String.join(", ", addJobCategorys);
+
+
                 AnnouncementReadDetailRes announcementReadDetailRes = AnnouncementReadDetailRes.builder()
                         .announcementIdx(announcementIdx)
                         .companyIdx(company.getIdx())
@@ -232,7 +246,7 @@ public class AnnouncementService {
                         .title(announcement.getTitle())
                         .selectForm(announcement.getSelectForm())
                         .imgUrl(announcement.getImgUrl())
-                        .jobCategory(announcement.getJobCategory())
+                        .jobCategory(jobCategoryString)
                         .jobTitle(announcement.getJobTitle())
                         .recruitedNum(announcement.getRecruitedNum())
                         .careerBase(announcement.getCareerBase())

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/model/entity/PersonalInfo.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/model/entity/PersonalInfo.java
@@ -36,7 +36,7 @@ public class PersonalInfo {
     @Column(length = 30)
     private String tel;
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false)
     private String address;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/sabujaks/irs/domain/system/DataInit.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/system/DataInit.java
@@ -8,6 +8,9 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @RequiredArgsConstructor
 @Component
 public class DataInit {
@@ -164,6 +167,82 @@ public class DataInit {
                 teamRepository.save(Team.builder()
                         .teamName(team)
                         .build());
+            }
+        }
+
+        // 모집직무 job_category
+        if(baseInfoRepository.findById(62L).isEmpty()){
+            // 모집직무 카테고리 대분류 추가
+            String groupName = "job_category";
+            String[] descriptions = {
+                    "기획&전략", "교육", "고객상담&TM", "IT&개발", "마케팅",
+                    "영업", "인사", "재무&회계", "법무", "홍보&PR",
+                    "디자인", "생산&제조", "연구개발(R&D)", "물류", "구매",
+                    "건설&토목", "의료", "연구", "법무&특허", "서비스",
+                    "비서&총무", "전략기획", "엔지니어", "유통&판매", "리스크관리",
+                    "품질관리", "공공행정", "광고&미디어", "항공", "호텔&외식"
+            };
+
+            // 소분류 데이터
+            Map<String, String[]> subCategories = new HashMap<>();
+            subCategories.put("기획&전략", new String[]{"사업기획", "전략수립", "경영기획", "프로젝트관리", "사업분석", "시장조사", "리스크관리"});
+            subCategories.put("교육", new String[]{"교육기획", "학습상담", "학원생관리", "교육운영", "교육컨설팅", "교육콘텐츠기획"});
+            subCategories.put("고객상담&TM", new String[]{"고객상담", "TM상담", "해피콜", "클레임관리", "고객데이터관리", "서비스품질관리"});
+            subCategories.put("IT&개발", new String[]{"프론트엔드개발", "백엔드개발", "모바일개발", "웹개발", "데이터베이스관리", "시스템엔지니어", "소프트웨어테스트"});
+            subCategories.put("마케팅", new String[]{"디지털마케팅", "콘텐츠마케팅", "마케팅전략", "브랜드관리", "광고기획", "소셜미디어관리", "시장분석"});
+            subCategories.put("영업", new String[]{"B2B영업", "B2C영업", "영업기획", "영업관리", "신규사업개발", "영업지원", "채널관리"});
+            subCategories.put("인사", new String[]{"인사기획", "채용", "인재육성", "조직문화관리", "노무관리", "성과관리", "복리후생"});
+            subCategories.put("재무&회계", new String[]{"재무관리", "회계", "세무", "재무기획", "자금관리", "리스크관리", "재무분석"});
+            subCategories.put("법무", new String[]{"법무지원", "계약관리", "소송관리", "기업법무", "지적재산권관리", "컴플라이언스", "규제대응"});
+            subCategories.put("홍보&PR", new String[]{"미디어관리", "언론대응", "홍보전략", "브랜드PR", "내부커뮤니케이션", "이벤트기획"});
+            subCategories.put("디자인", new String[]{"그래픽디자인", "UI/UX디자인", "웹디자인", "광고디자인", "브랜드디자인", "제품디자인", "패키지디자인"});
+            subCategories.put("생산&제조", new String[]{"생산관리", "공정관리", "설비관리", "품질관리", "자재관리", "안전관리", "생산계획"});
+            subCategories.put("연구개발(R&D)", new String[]{"제품개발", "기술연구", "시장조사", "특허관리", "신제품기획", "기술기획", "기술동향분석"});
+            subCategories.put("물류", new String[]{"물류관리", "재고관리", "유통기획", "운송관리", "창고관리", "국제물류", "SCM관리"});
+            subCategories.put("구매", new String[]{"구매관리", "원가관리", "공급업체관리", "구매계약", "수입관리", "원자재구매"});
+            subCategories.put("건설&토목", new String[]{"건축설계", "토목설계", "현장관리", "공사관리", "안전관리", "프로젝트관리", "자재관리"});
+            subCategories.put("의료", new String[]{"간호", "진료지원", "의료기기관리", "환자관리", "의료코디네이터", "약사", "의무기록관리"});
+            subCategories.put("연구", new String[]{"임상연구", "바이오연구", "의약품연구", "화학분석", "기초과학연구", "실험실관리", "기술연구"});
+            subCategories.put("법무&특허", new String[]{"특허출원", "지식재산권관리", "법무상담", "계약관리", "소송대응", "컴플라이언스"});
+            subCategories.put("서비스", new String[]{"고객서비스", "서비스기획", "리셉션", "클레임처리", "CS운영", "서비스교육"});
+            subCategories.put("비서&총무", new String[]{"비서업무", "일정관리", "총무관리", "사무지원", "자산관리", "문서관리", "회의관리"});
+            subCategories.put("전략기획", new String[]{"사업전략수립", "시장분석", "재무분석", "위험관리", "프로젝트관리", "경쟁사분석", "장기계획수립"});
+            subCategories.put("엔지니어", new String[]{"기계설계", "전기설계", "시스템엔지니어", "자동화설비관리", "설비보전", "기술지원", "제품개발"});
+            subCategories.put("유통&판매", new String[]{"판매관리", "매장관리", "상품기획", "유통기획", "재고관리", "프로모션기획", "매출분석"});
+            subCategories.put("리스크관리", new String[]{"금융리스크관리", "재무리스크관리", "위험분석", "규제대응", "자산운용", "보안관리"});
+            subCategories.put("품질관리", new String[]{"QC", "QA", "품질보증", "제품검사", "공정관리", "불량분석", "고객불만처리"});
+            subCategories.put("공공행정", new String[]{"행정기획", "정책분석", "공공사업관리", "국제협력", "정책평가", "공공서비스개선"});
+            subCategories.put("광고&미디어", new String[]{"광고기획", "미디어플래닝", "방송제작", "광고대행", "PR전략", "콘텐츠기획", "미디어구매"});
+            subCategories.put("항공", new String[]{"항공기정비", "승무원", "공항운영", "화물운송", "비행기정비", "항공사운영"});
+            subCategories.put("호텔&외식", new String[]{"호텔운영", "레스토랑운영", "조리", "객실관리", "외식기획", "행사기획", "프론트관리"});
+
+
+            for (int i = 0; i < descriptions.length; i++) {
+                String code = String.format("job_%03d", i + 1);
+                String groupName1 = descriptions[i];
+
+                // 대분류 저장
+                BaseInfo baseInfo = BaseInfo.builder()
+                        .groupName(groupName)
+                        .code(code)
+                        .description(groupName1)
+                        .parentCode(null)
+                        .build();
+                baseInfoRepository.save(baseInfo);
+
+                // 소분류 추가
+                String[] subCategoryDescriptions = subCategories.get(groupName1);
+                if (subCategoryDescriptions != null) {
+                    for (int j = 0; j < subCategoryDescriptions.length; j++) {
+                        BaseInfo subBaseInfo = BaseInfo.builder()
+                                .groupName(groupName1)
+                                .code(String.format("%s_%03d", code, j + 1))
+                                .description(subCategoryDescriptions[j])
+                                .parentCode(code)
+                                .build();
+                        baseInfoRepository.save(subBaseInfo);
+                    }
+                }
             }
         }
     }

--- a/backend/src/main/java/com/sabujaks/irs/domain/system/controller/BaseInfoController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/system/controller/BaseInfoController.java
@@ -1,6 +1,7 @@
 package com.sabujaks.irs.domain.system.controller;
 
 
+import com.sabujaks.irs.domain.system.model.response.BaseInfoReadRes;
 import com.sabujaks.irs.domain.system.model.response.CategoryRes;
 import com.sabujaks.irs.domain.system.service.BaseInfoService;
 import com.sabujaks.irs.global.common.exception.BaseException;
@@ -25,6 +26,15 @@ public class BaseInfoController {
     public ResponseEntity<BaseResponse<CategoryRes>> getCategory(String keyword) throws BaseException {
 
         List<CategoryRes> response = baseInfoService.getCategory(keyword);
+        return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.BASE_INFO_BENEFIT_CATEGORY_SEARCH_SUCCESS, response));
+    }
+
+    // 소분류 카테고리 조회 (모집직무 조회에 사용, 소분류로 대분류 설명과 소분류 설명 가져올때 사용)
+    @GetMapping("/read/info")
+    public ResponseEntity<BaseResponse<BaseInfoReadRes>> getInfo(String codes) throws BaseException {
+
+        List<BaseInfoReadRes> response = baseInfoService.getInfo(codes);
+        // 베이스 메세지 추가해서 바꾸기
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.BASE_INFO_BENEFIT_CATEGORY_SEARCH_SUCCESS, response));
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/system/model/response/BaseInfoReadRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/system/model/response/BaseInfoReadRes.java
@@ -1,0 +1,15 @@
+package com.sabujaks.irs.domain.system.model.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BaseInfoReadRes {
+    private String code; // 소분류 코드
+    private String description; // 소분류 설명
+    private String groupName; // 그룹네임 (부모 description)
+    private String parentCode; // 부모 코드 (부모 code)
+}

--- a/backend/src/main/java/com/sabujaks/irs/domain/system/repository/BaseInfoRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/system/repository/BaseInfoRepository.java
@@ -15,7 +15,7 @@ public interface BaseInfoRepository extends JpaRepository<BaseInfo, Long> {
     @Query("SELECT b FROM BaseInfo b WHERE b.groupName = :groupName AND b.code IN :codes")
     List<BaseInfo> findAllByGroupNameAndCodeIn(@Param("groupName") String groupName, @Param("codes") List<String> codes);
 
-    List<BaseInfo> findByCodeIn(List<String> companyBenefitsCodes);
+    List<BaseInfo> findByCodeIn(List<String> codes);
 
     @Query("SELECT b FROM BaseInfo b WHERE b.code LIKE %:inCode% AND b.parentCode IS NULL")
     List<BaseInfo> findAllByCodeContainingAndParentCodeIsNull(@Param("inCode") String inCode);

--- a/backend/src/main/java/com/sabujaks/irs/domain/system/service/BaseInfoService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/system/service/BaseInfoService.java
@@ -1,6 +1,7 @@
 package com.sabujaks.irs.domain.system.service;
 
 import com.sabujaks.irs.domain.system.model.entity.BaseInfo;
+import com.sabujaks.irs.domain.system.model.response.BaseInfoReadRes;
 import com.sabujaks.irs.domain.system.model.response.CategoryRes;
 import com.sabujaks.irs.domain.system.model.response.SubcategoryRes;
 import com.sabujaks.irs.domain.system.repository.BaseInfoRepository;
@@ -8,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -40,5 +43,25 @@ public class BaseInfoService {
         }
 
         return categoryResList;
+    }
+
+    public List<BaseInfoReadRes> getInfo(String codes) {
+        // codes가 쉼표를 포함하는지 확인하고, 포함되면 split, 그렇지 않으면 단일 코드로 리스트 생성
+        List<String> codeList = codes.contains(",") ? Arrays.asList(codes.split(",")) : List.of(codes);
+
+        List<BaseInfo> baseInfoList = baseInfoRepository.findByCodeIn(codeList);
+
+        List<BaseInfoReadRes> baseInfoReadResList = new ArrayList<>();
+        // 검색 결과를 BaseInfoReadRes 리스트로 변환하여 반환
+        for (BaseInfo baseInfo : baseInfoList) {
+            BaseInfoReadRes baseInfoReadRes = BaseInfoReadRes.builder()
+                    .code(baseInfo.getCode())
+                    .description(baseInfo.getDescription())
+                    .groupName(baseInfo.getGroupName())
+                    .parentCode(baseInfo.getParentCode())
+                    .build();
+            baseInfoReadResList.add(baseInfoReadRes);
+        }
+        return baseInfoReadResList;
     }
 }

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -120,7 +120,7 @@ public enum BaseResponseMessage {
     INTERVIEW_EVALUATE_READ_ALL_FAIL(true, 6401, "지원자들의 면접 평가 결과를 불러오는데 실패했습니다."),
 
     // BASE_INFO 기준정보 관련 7000~7999
-    BASE_INFO_BENEFIT_CATEGORY_SEARCH_SUCCESS(true, 7000, "기준정보 중 복리후생 카테고리 조회에 성공했습니다."),
+    BASE_INFO_BENEFIT_CATEGORY_SEARCH_SUCCESS(true, 7000, "기준정보 중 카테고리 조회에 성공했습니다."),
 
     TOTAL_PROCESS_CREATE_SUCCESS(true, 8000, "통합 지원 프로세스 생성에 성공했습니다."),
     TOTAL_PROCESS_CREATE_FAIL(true, 8001, "통합 지원 프로세스 생성에 실패했습니다."),

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,6 +13,10 @@ cloud:
     s3:
       bucket: ${S3_BUCKET_NAME}
 spring:
+  servlet:
+    multipart:
+      max-file-size: 2MB
+      max-request-size: 2MB
   jwt:
     secret: ${JWT_SECRET}
   datasource:


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #451
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
공고 관련 기능 로직 수정과 카테고리 부분 BaseInfo 활용 방향으로 개선
<br>

## ✅ 주요 작업 부분
조회 시 카테고리 설명으로 나오게 백엔드 조회 코드 수정
- base_info 테이블 job_category 추가 = DataInit
- system 패키지 서비스 추가 = 코드로 BaseInfo 엔티티 조회 메서드
- announcement 패키지 서비스 수정 = 공고 상세조회 시 jobCategory 넣는 부분

근무지역 컬럼 및 다른 컬럼 몇 가지 길이 늘리기 region
이미지 업로드일 때 카테고리 db에 들어가게 수정
공고 생성 시 채용담당자 토큰없을때 null 오류 시큐리티 설정에 추가
<br>