### PR TITLE
[#413][Refactor] 공고 관련 전체 페이지 개선

### DIFF
--- a/frontend/src/pages/recruiter/announce/AnnounceDetailPage.vue
+++ b/frontend/src/pages/recruiter/announce/AnnounceDetailPage.vue
@@ -98,7 +98,7 @@ onMounted(() => {
 <style scoped>
 .container {
     width: 80%;
-    margin: 0 auto;
+    margin: 150px 200px;
 }
 
 #content {

--- a/frontend/src/pages/recruiter/announce/AnnounceMainPage.vue
+++ b/frontend/src/pages/recruiter/announce/AnnounceMainPage.vue
@@ -101,7 +101,7 @@ const totalPages = computed(() => {
 #content {
   flex: 1;
   margin-left: 200px; /* 사이드바 너비만큼 왼쪽 여백 추가 */
-  padding: 0 0 150px 0;
+  padding: 150px 0;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;

--- a/frontend/src/pages/recruiter/announce/AnnounceRegisterStep2Page.vue
+++ b/frontend/src/pages/recruiter/announce/AnnounceRegisterStep2Page.vue
@@ -123,7 +123,7 @@ const saveForm = () => {
 
 .container {
     width: 80%;
-    margin: 0 auto;
+    margin: 150px 200px;
 }
 
 #content {

--- a/frontend/src/pages/recruiter/company/CompanyInfoPage.vue
+++ b/frontend/src/pages/recruiter/company/CompanyInfoPage.vue
@@ -156,9 +156,9 @@ onMounted(async () => {
 
 <template>
   <MainHeaderComponent />
-  <div class="container padding-100 0 0 0">
+  <div class="container padding-100 0 0 0" style="margin: 150px 0 200px 200px;">
     <MainSideBarComponent />
-    <div id="content">
+    <div id="content" style="padding: 100px 100px;">
       <!-- 기업 정보 등록 섹션 -->
       <div v-if="companyStore.companyInfo.saved === 'N'" id="createSections">
         <h1>기업 정보 등록</h1>

--- a/frontend/src/stores/UseAnnouncementStore.js
+++ b/frontend/src/stores/UseAnnouncementStore.js
@@ -170,7 +170,7 @@ export const UseAnnouncementStore = defineStore('announcement', {
 
 
         // 공고 등록 함수
-        async createAnnouncement(selectedCategories, fields, fields2, router) {
+        async createAnnouncement(jobCategory, fields, fields2, router) {
             try {
                 const formDataCreate = new FormData();
 
@@ -214,26 +214,26 @@ export const UseAnnouncementStore = defineStore('announcement', {
 
                 // 상태 객체를 toRaw로 비반응형으로 변환
                 const rawFormData = toRaw(this.formData);
-                const rawSelectedCategories = toRaw(selectedCategories.value);
+                // const rawSelectedCategories = toRaw(selectedCategories.value);
 
-                // 대분류와 소분류를 결합한 형태로 변환
-                const jobCategoryList = Object.keys(rawSelectedCategories).reduce((acc, category) => {
-                    const subcategories = rawSelectedCategories[category];
-                    subcategories.forEach(subcategory => {
-                        acc.push(`${category} > ${subcategory}`);
-                    });
-                    return acc;
-                }, []);
+                // // 대분류와 소분류를 결합한 형태로 변환
+                // const jobCategoryList = Object.keys(rawSelectedCategories).reduce((acc, category) => {
+                //     const subcategories = rawSelectedCategories[category];
+                //     subcategories.forEach(subcategory => {
+                //         acc.push(`${category} > ${subcategory}`);
+                //     });
+                //     return acc;
+                // }, []);
 
-                // 리스트를 쉼표로 구분된 문자열로 변환
-                const jobCategoryString = jobCategoryList.join(", ");
+                // // 리스트를 쉼표로 구분된 문자열로 변환
+                // const jobCategoryString = jobCategoryList.join(", ");
 
                 // 전송할 AnnouncementCreateReq 객체 생성
                 const AnnouncementCreateReq = {
                     title: rawFormData.title, // 공고제목
                     selectForm: 0, // 양식선택
 
-                    jobCategoryList: jobCategoryString, // 직무 카테고리에서 .value로 접근하여 일반 데이터로 변환
+                    jobCategoryList: jobCategory, // 직무 카테고리에서 .value로 접근하여 일반 데이터로 변환
                     jobTitle: rawFormData.recruitmentFieldName, // 모집분야명
                     recruitedNum: rawFormData.numberOfRecruit, // 모집인원
                     careerBase: rawFormData.isNewbie ? "신입" : rawFormData.isExperienced ? "경력" : "", // 경력

--- a/frontend/src/stores/UseBaseInfoStore.js
+++ b/frontend/src/stores/UseBaseInfoStore.js
@@ -4,10 +4,10 @@ import { backend } from '@/const';
 
 export const UseBaseInfoStore = defineStore('baseInfo', {
     state: () => ({
-        categories: [], // 복리후생 카테고리 및 소분류 데이터를 저장할 배열
+        categories: [], // 카테고리 및 소분류 데이터를 저장할 배열
     }),
     actions: {
-        // 복리후생 카테고리 및 소분류 데이터 조회
+        // 카테고리 및 소분류 데이터 조회
         async fetchCategories(keyword) {
             try {
                 const response = await axios.get(`${backend}/base-info/read/category?keyword=${keyword}`, {
@@ -16,10 +16,10 @@ export const UseBaseInfoStore = defineStore('baseInfo', {
                 });
                 const data = response.data;
                 this.categories = data.result; // 백엔드에서 받은 데이터를 상태에 저장
-                console.log(data);
+                console.log(data.result);
             } catch (error) {
-                console.error('복리후생 카테고리 데이터를 불러오지 못했습니다:', error);
-                throw new Error(error.response?.data?.message || '복리후생 카테고리 데이터 조회 실패');
+                console.error('카테고리 데이터를 불러오지 못했습니다:', error);
+                throw new Error(error.response?.data?.message || '카테고리 데이터 조회 실패');
             }
         },
     }


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #413
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
채용담당자, 지원자 공고 관련 전체 페이지 개선
<br>

## ✅ 주요 작업 부분
이미지 업로드 버튼 디자인 수정
이미지 업로드 배경색 수정
이미지 업로드일때 카테고리 db에 들어가게 필수 처리 추가
공고 등록 시 복리후생 조회 디자인 변경
지원 접수 기간 날짜 부분 한 칸 밑으로 내리기
면접 횟수 -> 전형절차 자동으로 들어가게 수정
지원서 폼 조립 상단 여백 조정
지원서 폼 조립 후 /recruiter/announce 페이지로 리다이렉트
카테고리(현재 string) 코드 넘겨주기 처리
지원자 메인페이지(목록 조회) : 메인에서 공고 상세 들어갈 때 새창 뜨는 부분 수정 (새창 뜨면서 헤더가 로그아웃된 것 처럼 변경됨 -> a 태그에 타겟 삭제해서 해결)
공고 관리 페이지에서 채용담당자가 등록한 공고 목록 조회 페이지 페이징 처리
<br>
