### PR TITLE
[#474][Refactor] 채용담당자 공고 상세 조회 페이지 지원서 폼 조회 추가

### DIFF
--- a/frontend/src/pages/recruiter/announce/AnnounceDetailPage.vue
+++ b/frontend/src/pages/recruiter/announce/AnnounceDetailPage.vue
@@ -3,7 +3,38 @@
     <div class="container">
         <MainSideBarComponent></MainSideBarComponent>
         <div id="content">
-            <h1 v-if="announcementDetail.title">{{ announcementDetail.title }} 공고 상세 정보</h1>
+            <h1 style="margin-top: 50px;" v-if="announcementDetail.title">{{ announcementDetail.title }} 공고 상세 정보</h1>
+            <button class="custom-button" @click="goToForm">조립된 지원서 폼 확인</button>
+
+            <!-- 모달 템플릿 -->
+            <div v-if="showModal" class="modal">
+                <div class="modal-content">
+                    <span class="close-button" @click="showModal = false">&times;</span>
+
+                    <!-- 지원서 항목 리스트 -->
+                    <div>
+                        <h3>지원서 항목</h3>
+                        <ul class="styled-list" style="display: flex;">
+                            <li style="margin: 10px 10px;" v-for="(form, index) in customFormStore.custom.customFormList" :key="index">{{ form }}
+                            </li>
+                        </ul>
+                    </div>
+                    <br>
+
+                    <!-- 서술형 항목 리스트 -->
+                    <div
+                        v-if="customFormStore.custom.customLetterList && customFormStore.custom.customLetterList.length > 0">
+                        <h3>자기소개서 문항</h3>
+                        <ul class="styled-list">
+                            <li style="border-bottom: 1px solid #e0e0e0;" v-for="(letter, index) in customFormStore.custom.customLetterList" :key="index">
+                                {{ letter.split(' / ')[0] }} <br />
+                                <small>글자 제한: {{ letter.split(' / ')[1] }}자</small>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
             <div class="detail-section">
                 <h2>공고 정보</h2>
                 <p v-if="announcementDetail.title"><strong>공고명:</strong> {{ announcementDetail.title }}</p>
@@ -71,12 +102,17 @@
 import MainHeaderComponent from "@/components/recruiter/MainHeaderComponent.vue";
 import MainSideBarComponent from "@/components/recruiter/MainSideBarComponent.vue";
 import { ref, onMounted } from "vue";
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { UseAnnouncementStore } from '@/stores/UseAnnouncementStore';
+import { UseCustomFormStore } from "@/stores/UseCustomFormStore";
+import { useToast } from 'vue-toastification';
 
 const route = useRoute();
+const router = useRouter();
 const announcementStore = UseAnnouncementStore();
+const customFormStore = UseCustomFormStore();
 const announcementDetail = ref({});
+const showModal = ref(false); // 모달 상태 설정
 
 // 공고 세부 정보 불러오기
 const fetchAnnouncementDetail = async () => {
@@ -88,6 +124,39 @@ const fetchAnnouncementDetail = async () => {
 const splitConditions = (conditions) => {
     if (!conditions) return [];
     return conditions.split('//');
+};
+
+// 지원서 폼 조회하고, 받아온 값이 있으면 모달창으로 확인, 없으면 지원서폼 조립 페이지로 이동
+const goToForm = async () => {
+
+    try {
+        await customFormStore.readForm(route.params.announcementIdx);
+
+        if (customFormStore.custom && customFormStore.custom.customFormList && customFormStore.custom.customFormList.length > 0) {
+            // 조회 성공 시 모달을 표시
+            showModal.value = true;
+            console.log(customFormStore.custom);
+        }
+
+        // if (customFormStore.custom.customFormList.length > 0) {
+        //     // 조회 성공 시 모달을 표시
+        //     showModal.value = true; // 모달 표시를 위한 상태 설정 (예: ref를 활용)
+        //     console.log(customFormStore.custom);
+        // }
+    } catch (error) {
+        // 에러 캐치 시 페이지 이동
+        const toast = useToast();
+        // console.log(error);
+        const errorMessage = error.message + ' 조립 페이지로 이동합니다.';
+        toast.error(errorMessage);
+
+        setTimeout(() => {
+            router.push({
+                name: 'AnnouncementCreateStep2',
+                params: { announcementIdx: route.params.announcementIdx, title: announcementDetail.value.title },
+            });
+        }, 2000); // 2초 후 페이지 이동
+    }
 };
 
 onMounted(() => {
@@ -103,7 +172,7 @@ onMounted(() => {
 
 #content {
     flex: 1;
-    margin-left: 200px;
+    margin-left: 158px;
     padding: 0 0 150px 0;
     display: flex;
     flex-direction: column;
@@ -136,4 +205,86 @@ img {
     border-radius: 5px;
     margin-top: 10px;
 }
+
+/* 지원서 폼 확인 버튼 스타일 */
+.custom-button {
+    background-color: #212b36;
+    color: white;
+    border-radius: 5px;
+    padding: 13px 10px;
+    margin-left: auto;
+    margin-bottom: 10px;
+    border: none;
+    cursor: pointer;
+    /* font-weight: bold; */
+    font-size: 16px;
+    /* transition: background-color 0.3s ease; */
+}
+
+.custom-button:hover {
+    background-color: #37404a;
+}
+
+/* 모달 스타일 */
+.modal {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 9999;
+}
+
+.modal-content {
+    position: relative;
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    width: 60%;
+    max-width: 600px;
+    text-align: center;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.close-button {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    font-size: 24px;
+    font-weight: bold;
+    cursor: pointer;
+    color: #333;
+}
+
+.close-button:hover {
+    color: #000;
+}
+
+.styled-list {
+    list-style-type: none; /* 기본 목록 스타일 제거 */
+    padding: 0;
+    margin: 0;
+}
+
+.styled-list li {
+    padding: 10px 0;
+    /* border-bottom: 1px solid #e0e0e0; */
+    font-size: 16px;
+    color: #333;
+}
+
+.styled-list li:last-child {
+    border-bottom: none; 
+    /* 마지막 항목은 구분선 제거 */
+}
+
+.styled-list small {
+    font-size: 14px;
+    color: #666;
+}
+
 </style>

--- a/frontend/src/pages/recruiter/announce/AnnounceRegisterStep1Page.vue
+++ b/frontend/src/pages/recruiter/announce/AnnounceRegisterStep1Page.vue
@@ -577,8 +577,8 @@ export default {
               </div>
             </div>
           </div>
-          <p style="font-size: large;">이미지 업로드 양식 - 이미지를 업로드 하고 템플릿 작성 양식으로 이동하여 *필수*값을 꼭 입력한 후 등록해 주세요. <br>
-            템플릿 작성 양식 - 템플릿의 정보를 모두 작성 후 등록해 주세요. </p>
+          <p style="font-size: large;">📢 이미지 업로드 양식 - 이미지를 업로드 하고 템플릿 작성 양식으로 이동하여 *필수*값을 꼭 입력한 후 등록해 주세요. <br>
+            📢 템플릿 작성 양식 - 템플릿의 정보를 모두 작성 후 등록해 주세요. </p>
         </div>
 
         <hr style="border: 0.5px solid #abadb8; margin: 30px 0;">
@@ -1010,7 +1010,7 @@ export default {
 
         <!-- 다음 스텝 버튼 -->
         <div class="submit-section">
-          <p style="font-size: large;">이미지 업로드 시, 템플릿 작성 양식으로 이동하여 *필수*값을 꼭 입력한 후 등록해 주세요.</p>
+          <p style="font-size: large;">📢 이미지 업로드 시, 템플릿 작성 양식으로 이동하여 *필수*값을 꼭 입력한 후 등록해 주세요.</p>
           <button @click="alreadyFun" id="buildFormBtn">공고 등록 후 지원서 폼 조립하기</button>
         </div>
       </div>
@@ -1075,8 +1075,8 @@ input[type="number"] {
 }
 
 .container-regi {
-  width: 90%;
-  margin: 0px 50px 40px 50px;
+  width: 80%;
+  margin: 0px 50px 40px 158px;
   background-color: white;
   padding: 20px;
   /* border-radius: 10px; */

--- a/frontend/src/pages/recruiter/announce/AnnounceRegisterStep2Page.vue
+++ b/frontend/src/pages/recruiter/announce/AnnounceRegisterStep2Page.vue
@@ -3,8 +3,11 @@
     <div class="container">
         <MainSideBarComponent></MainSideBarComponent>
         <div id="content">
-            <div style="display: flex; justify-content: space-between;">
-                <h2>[{{ route.params.title }}] 공고<br>지원서 폼 조립</h2>
+            <div style="display: flex; justify-content: space-between; margin-top: 50px">
+                <div>
+                    <h2>[{{ route.params.title }}] 공고 지원서 폼 조립</h2><br>
+                    <p style="font-size: 16px;">📢 지원서에 받을 항목을 선택하고 추가하세요. 자기소개서 항목은 문항까지 추가해 주세요.</p>
+                </div>
                 <!-- 저장 버튼 -->
                 <button @click="saveForm" class="save-button">폼 저장</button>
             </div>
@@ -128,11 +131,11 @@ const saveForm = () => {
 
 #content {
     /* flex: 1; */
-    margin-left: 200px;
+    margin-left: 158px;
     /* 사이드바 너비만큼 왼쪽 여백 추가 */
     padding: 0 0 150px 0;
     display: flex;
-    /* flex-direction: column; */
+    flex-direction: column;
     box-sizing: border-box;
 }
 

--- a/frontend/src/pages/recruiter/company/CompanyInfoPage.vue
+++ b/frontend/src/pages/recruiter/company/CompanyInfoPage.vue
@@ -156,9 +156,9 @@ onMounted(async () => {
 
 <template>
   <MainHeaderComponent />
-  <div class="container padding-100 0 0 0" style="margin: 150px 0 200px 200px;">
+  <div class="container" style="margin: 150px 0 200px 200px;">
     <MainSideBarComponent />
-    <div id="content" style="padding: 100px 100px;">
+    <div id="content" style="padding: 50px 158px 100px 158px;">
       <!-- 기업 정보 등록 섹션 -->
       <div v-if="companyStore.companyInfo.saved === 'N'" id="createSections">
         <h1>기업 정보 등록</h1>
@@ -285,7 +285,7 @@ onMounted(async () => {
       </div>
 
       <!-- 기업 정보 조회 섹션 -->
-      <div v-else id="readSections" style="margin: 0 0 100px 0;">
+      <div v-else id="readSections">
         <h1>{{ companyStore.companyInfo.name }} 기업 정보</h1>
         <div class="image-preview-container">
           <!-- 이미지 리스트를 보여줌 -->

--- a/frontend/src/pages/recruiter/resume/ResumeListPage.vue
+++ b/frontend/src/pages/recruiter/resume/ResumeListPage.vue
@@ -22,7 +22,7 @@
             v-for="(resume, index) in paginatedResumes"
             :key="index"
             @click="handleRowClick(resume)"
-            style="cursor: pointer"
+            class="hoverable-row"
           >
             <td>{{ resumeStore.resumeListPage.totalElements - ((currentPage - 1) * pageSize + index) }}</td>
             <td>{{ resume.seekerName }}</td>
@@ -161,6 +161,16 @@ th {
     color: white;
     padding: 10px;
     border-radius: 5px;
+}
+
+/* 테이블 행 hover 시 색깔 변화 */
+.hoverable-row {
+  transition: background-color 0.3s ease;
+}
+
+.hoverable-row:hover {
+  background-color: #f6f6f6; /* 마우스 올렸을 때 약간 어둡게 변경 */
+  cursor: pointer;
 }
 
 .pagination {

--- a/frontend/src/pages/recruiter/resume/ResumeMainPage.vue
+++ b/frontend/src/pages/recruiter/resume/ResumeMainPage.vue
@@ -17,7 +17,7 @@
                     v-for="(announcement, index) in paginatedAnnouncements"
                     :key="index"
                     @click="handleRowClick(announcement)"
-                    style="cursor: pointer"
+                    class="hoverable-row"
                 >
                 <td>{{ announcementStore.announcementsPage.totalElements - ((currentPage - 1) * pageSize + index) }}</td>
                 <td>{{ formatDate(announcement.announcementStart) }} - {{ formatDate(announcement.announcementEnd) }}</td>
@@ -166,6 +166,16 @@ th {
 
 #size-buttons button:hover {
   background-color: #ddd;
+}
+
+/* 테이블 행 hover 시 색깔 변화 */
+.hoverable-row {
+  transition: background-color 0.3s ease;
+}
+
+.hoverable-row:hover {
+  background-color: #f6f6f6; /* 마우스 올렸을 때 약간 어둡게 변경 */
+  cursor: pointer;
 }
 
 .pagination {

--- a/frontend/src/stores/UseCompanyStore.js
+++ b/frontend/src/stores/UseCompanyStore.js
@@ -168,7 +168,7 @@ export const UseCompanyStore = defineStore('company', {
                     // 알림이 끝난 후 새로고침 (2초 후)
                     setTimeout(() => {
                         window.location.reload();
-                    }, 2000); // 2000ms = 2초 (알림 지속 시간에 맞추어 조정)
+                    }, 3000); // 2000ms = 2초 (알림 지속 시간에 맞추어 조정)
                 }
             } catch (error) {
                 console.error('기업 정보 등록 실패:', error);

--- a/frontend/src/stores/UseCustomFormStore.js
+++ b/frontend/src/stores/UseCustomFormStore.js
@@ -5,7 +5,7 @@ import { useToast } from 'vue-toastification';
 
 export const UseCustomFormStore = defineStore('customform', {
     state: () => ({
-
+        custom: [], // 지원서폼 리스트
     }),
     actions: {
         // 지원서 폼 저장 로직
@@ -53,7 +53,30 @@ export const UseCustomFormStore = defineStore('customform', {
                 toast.error('폼 저장에 실패하였습니다. ' + error.response.data.message);
             }
 
-        }
+        },
+
+        // 지원서 폼 조회
+        async readForm(announcementIdx) {
+            try {
+                const response = await axios.get(
+                    `${backend}/announcement/custom-form/read?announcementIdx=${announcementIdx}`,
+                    {
+                        headers: { 'Content-Type': 'application/json' },
+                        withCredentials: true
+                    });
+
+                if(response && response.data && response.data.result) {
+                    this.custom = response.data.result; // 백엔드에서 가져온 데이터를 저장  
+                    // console.log(this.custom);
+                }
+
+            } catch (error) {
+                console.error('폼 조회 중 오류 발생:', error);
+
+                throw new Error(error.response.data.message); // 에러 메시지 예외 처리로 던지기
+
+            }
+        },
 
     }
 });


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #474
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
지원서 폼과 자기소개서 항목도 조회 가능하게 추가했습니다. 조회할 정보가 없을 시 조립페이지로 이동합니다.
<br>

## ✅ 주요 작업 부분
공고 관리 페이지에서 공고 하나 선택 시, 이동하는 공고 상세 조회 페이지에 기능 추가
조립된 지원서 폼 확인 버튼 추가
데이터가 있으면 모달창으로 출력
![image](https://github.com/user-attachments/assets/34475f56-4501-400d-8e54-fa48cd7fa256)

데이터가 없으면 지원서 폼 조립 페이지로 리다이렉트

공고와 기업 관련 디자인 틀어진 부분 정리
지원서 관리 페이지에 호버 스타일 추가
<br>
