### PR TITLE
[#483][Refactor] 채용담당자 인터뷰 일정(신입, 경력, 일정조율) 페이지 생성된 일정 개수 표시

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/model/response/AnnouncementReadAllRes2.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/model/response/AnnouncementReadAllRes2.java
@@ -49,6 +49,9 @@ public class AnnouncementReadAllRes2 {
     // UUID 인증코드
     private String uuid;
 
+    private Integer countInterviewSchedule;
+    private Integer countReSchedule;
+
     // 관계 데이터
     private RecruiterRes recruiterRes;
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/response/InterviewScheduleRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/model/response/InterviewScheduleRes.java
@@ -23,4 +23,5 @@ public class InterviewScheduleRes {
     private Long teamIdx;
     private String companyName;
     private String announcementTitle;
+    private Integer countInterviewSchedule;
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/repository/InterviewScheduleRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/repository/InterviewScheduleRepository.java
@@ -54,4 +54,7 @@ public interface InterviewScheduleRepository extends JpaRepository<InterviewSche
 
     @Query("SELECT is FROM InterviewSchedule is WHERE is.interviewDate = :interviewDate AND is.team.idx = :teamIdx AND is.announcement.idx = :announcementIdx")
     Optional<List<InterviewSchedule>> findByInterviewDateAndTeamIdxAndAnnouncementIdx(String interviewDate, Long teamIdx, Long announcementIdx);
+
+    @Query("SELECT COUNT(is) FROM InterviewSchedule is WHERE is.announcement.idx = :announcementIdx")
+    Integer countInterviewScheduleByAnnouncementIdx(Long announcementIdx);
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/repository/ReScheduleRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/repository/ReScheduleRepository.java
@@ -14,4 +14,7 @@ public interface ReScheduleRepository extends JpaRepository<ReSchedule, Long> {
 
     @Query("SELECT r FROM ReSchedule r WHERE r.idx = :reScheduleIdx")
     Optional<ReSchedule> findByReScheduleIdx(Long reScheduleIdx);
+
+    @Query("SELECT COUNT(r) FROM ReSchedule r WHERE r.interviewSchedule.idx = :interviewScheduleIdx")
+    Integer countReScheduleByInterviewIdx(Long interviewScheduleIdx);
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/service/InterviewScheduleService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/interview_schedule/service/InterviewScheduleService.java
@@ -196,7 +196,7 @@ public class InterviewScheduleService {
                 List<EstimatorInfoGetRes> estimatorInfoGetResList = new ArrayList<>();
                 List<InterviewParticipate> participateResult = interviewParticipateRepository.findByInterviewScheduleIdxAndStatus(interviewSchedule.getIdx(), true).orElseThrow(() ->
                         new BaseException(BaseResponseMessage.INTERVIEW_PARTICIPATE_NOT_FOUND));
-
+                Integer count = interviewScheduleRepository.countInterviewScheduleByAnnouncementIdx(interviewSchedule.getAnnouncement().getIdx());
                 for(InterviewParticipate interviewParticipate : participateResult) {
                     Seeker seeker = seekerRepository.findBySeekerIdx(interviewParticipate.getSeeker().getIdx()).orElseThrow(()->new BaseException(BaseResponseMessage.MEMBER_NOT_FOUND));
                     Estimator estimator = estimatorRepository.findByEstimatorIdx(interviewParticipate.getEstimator().getIdx()).orElseThrow(()->new BaseException(BaseResponseMessage.ESTIMATOR_NOT_FOUND));
@@ -225,6 +225,7 @@ public class InterviewScheduleService {
                         .estimatorList(estimatorInfoGetResList)
                         .companyName(company.getName())
                         .announcementTitle(announcement.getTitle())
+                        .countInterviewSchedule(count)
                         .build());
             }
         }

--- a/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/common/responses/BaseResponseMessage.java
@@ -137,8 +137,9 @@ public enum BaseResponseMessage {
     RESCHEDULE_CREATE_SUCCESS(true, 8005, "면접 조율 신청 생성 완료"),
     RESCHEDULE_NOT_FOUND(false, 8006, "면접 조율 내역을 찾을 수 없습니다."),
     RESCHEDULE_SEARCH_ALL_SUCCESS(true, 8007, "면접 조율 내역 조회에 성공했습니다."),
+    INTERVIEW_SCHEDULE_COUNT_SUCCESS(true, 8008, "공고별 생성 면접 개수 조회에 성공했습니다."),
 
-    INTERVIEW_PARTICIPATE_NOT_FOUND(false, 8008, "면접 연관 정보를 찾을 수 없습니다."),
+    INTERVIEW_PARTICIPATE_NOT_FOUND(false, 8009, "면접 연관 정보를 찾을 수 없습니다."),
 
     // VIDEO_INTERVIEW 화상 면접 8100 ~ 8199
     VIDEO_INTERVIEW_CREATE_SUCCESS(true, 8100, "화상 면접 방 생성에 성공했습니다."),


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #465
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
채용담당자 인터뷰 일정 페이지(신입, 경력, 일정조율) 조회시, 생성된 면접일정 및 일정 조율 개수 표시했습니다.
<br>

## ✅ 주요 작업 부분
- InterviewScheduleRepository 로직 추가
- ReScheduleRepository 로직 추가
- AnnouncementService readAllAnnouncement 로직 변경
- AnnouncementReadAllRes2 반환 요소 추가

<br>