### PR TITLE
[#487][Refactor] 채용담당자 서류결과 일괄전송 로직 개선

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/alarm/model/entity/Alarm.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/alarm/model/entity/Alarm.java
@@ -2,6 +2,7 @@ package com.sabujaks.irs.domain.alarm.model.entity;
 
 import com.sabujaks.irs.domain.auth.model.entity.Seeker;
 import com.sabujaks.irs.domain.interview_schedule.model.entity.InterviewSchedule;
+import com.sabujaks.irs.domain.resume.model.entity.Resume;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -40,6 +41,10 @@ public class Alarm {
     @ManyToOne
     @JoinColumn(name = "interview_schedule_idx")
     private InterviewSchedule interviewSchedule;
+
+    @ManyToOne
+    @JoinColumn(name = "resume")
+    private Resume resume;
 
     public void setStatus(Boolean status) {
         this.status = status;

--- a/backend/src/main/java/com/sabujaks/irs/domain/alarm/repository/AlarmRepository.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/alarm/repository/AlarmRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     Optional<List<Alarm>> findBySeekerIdx(Long seekerIdx);
+
+    Optional<Alarm> findByResumeIdx(Long resumeIdx);
 }

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/controller/ResumeController.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/controller/ResumeController.java
@@ -10,7 +10,7 @@ import com.sabujaks.irs.global.common.responses.BaseResponseMessage;
 import com.sabujaks.irs.global.security.CustomUserDetails;
 import com.sabujaks.irs.global.utils.CloudFileUpload;
 import com.sabujaks.irs.global.utils.email.service.EmailService;
-import com.sabujaks.irs.global.utils.email.model.response.ResumeRejectRes;
+import com.sabujaks.irs.global.utils.email.model.response.ResumeResultRes;
 import com.sabujaks.irs.global.utils.email.service.EmailSenderSeeker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -152,8 +152,8 @@ public class ResumeController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody List<ResumeReadAllRecruiterRes> resumeList) throws BaseException {
 
-        List<ResumeRejectRes> rejectInfo = emailService.getRejectInfo(customUserDetails, resumeList);
-        emailSenderSeeker.sendResumeResultEmail(rejectInfo);
+        List<ResumeResultRes> resultInfo = emailService.getInfo(customUserDetails, resumeList);
+        emailSenderSeeker.sendResumeResultEmail(resultInfo);
         return ResponseEntity.ok(new BaseResponse(BaseResponseMessage.RESUME_READ_SUCCESS_RESUMED));
     }
 

--- a/backend/src/main/java/com/sabujaks/irs/domain/resume/model/entity/Resume.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/resume/model/entity/Resume.java
@@ -1,5 +1,6 @@
 package com.sabujaks.irs.domain.resume.model.entity;
 
+import com.sabujaks.irs.domain.alarm.model.entity.Alarm;
 import com.sabujaks.irs.domain.announcement.model.entity.Announcement;
 import com.sabujaks.irs.domain.auth.model.entity.Seeker;
 import com.sabujaks.irs.global.common.exception.BaseException;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Builder
@@ -45,4 +47,8 @@ public class Resume {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seeker_idx")
     private Seeker seeker;
+
+    // 알람 테이블과 1:n
+    @OneToMany(mappedBy = "resume")
+    private List<Alarm> alarm;
 }

--- a/backend/src/main/java/com/sabujaks/irs/global/utils/email/model/response/ResumeResultRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/utils/email/model/response/ResumeResultRes.java
@@ -5,10 +5,12 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class ResumeRejectRes {
+public class ResumeResultRes {
     private Long seekerIdx;
     private String seekerName;
     private String seekerEmail;
     private String companyName;
     private String announcementTitle;
+    private Long resumeIdx;
+    private Long announcementIdx;
 }

--- a/backend/src/main/java/com/sabujaks/irs/global/utils/email/service/EmailService.java
+++ b/backend/src/main/java/com/sabujaks/irs/global/utils/email/service/EmailService.java
@@ -5,8 +5,10 @@ import com.sabujaks.irs.domain.company.repository.CompanyRepository;
 import com.sabujaks.irs.domain.resume.model.entity.Resume;
 import com.sabujaks.irs.domain.resume.model.response.ResumeReadAllRecruiterRes;
 import com.sabujaks.irs.domain.resume.repository.ResumeRepository;
+import com.sabujaks.irs.domain.total_process.model.entity.TotalProcess;
+import com.sabujaks.irs.domain.total_process.repository.TotalProcessRepository;
 import com.sabujaks.irs.global.security.CustomUserDetails;
-import com.sabujaks.irs.global.utils.email.model.response.ResumeRejectRes;
+import com.sabujaks.irs.global.utils.email.model.response.ResumeResultRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,29 +21,27 @@ public class EmailService {
 
     private final ResumeRepository resumeRepository;
     private final CompanyRepository companyRepository;
+    private final TotalProcessRepository totalProcessRepository;
 
-    public List<ResumeRejectRes> getRejectInfo(CustomUserDetails customUserDetails, List<ResumeReadAllRecruiterRes> resumeList) {
-
+    public List<ResumeResultRes> getInfo(CustomUserDetails customUserDetails, List<ResumeReadAllRecruiterRes> resumeList) {
         Company company = companyRepository.findByRecruiterIdx(customUserDetails.getIdx()).get();
 
-        List<ResumeRejectRes> resumeRejectResList = new ArrayList<>();
-        for(ResumeReadAllRecruiterRes res: resumeList) {
-            Resume resume;
-            if(res.getResumeResult()) {
-                resume = resumeRepository.findByResumeIdx(res.getResumeIdx()).get();
-            } else {
-                continue;
-            }
+        List<ResumeResultRes> resumeResultResList = new ArrayList<>();
 
-            resumeRejectResList.add(ResumeRejectRes.builder()
+        for(ResumeReadAllRecruiterRes res: resumeList) {
+            Resume resume = resumeRepository.findByResumeIdx(res.getResumeIdx()).get();
+
+            resumeResultResList.add(ResumeResultRes.builder()
                             .seekerIdx(resume.getSeeker().getIdx())
                             .seekerName(resume.getSeeker().getName())
                             .seekerEmail(resume.getSeeker().getEmail())
                             .companyName(company.getName())
                             .announcementTitle(resume.getAnnouncement().getTitle())
+                            .resumeIdx(resume.getIdx())
+                            .announcementIdx(resume.getAnnouncement().getIdx())
                             .build());
         }
 
-        return resumeRejectResList;
+        return resumeResultResList;
     }
 }

--- a/backend/src/main/resources/templates/ResumeAcceptEmail.html
+++ b/backend/src/main/resources/templates/ResumeAcceptEmail.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Title</title>
+    <style>
+        .info-mail table, .info-mail td, .info-mail th{border: 0 !important; text-align: start}
+    </style>
+</head>
+
+<body>
+<div class="info-mail">
+    <div class="aHl"></div>
+    <div id=":i5" tabindex="-1"></div>
+    <div id=":ph" class="ii gt" jslog="20277; u014N:xr6bB; 1:WyIjdGhyZWFkLWY6MTgwOTMxODMzNTg0NjQwODI0OSJd;">
+        <div id=":pg" class="a3s aiL">
+            <table style="min-width: 800px; max-width: 1000px;" cellspacing="0" cellpadding="0" align="center">
+                <tbody>
+                <tr>
+                    <td align="center">
+                        <table style="width: 100%;" align="center">
+                            <tbody>
+                            <!-- 로고 이미지 -->
+                            <tr>
+                                <td width="100%" style="text-align: center;">
+                                    <a href="#" target="_blank" data-saferedirecturl="https://www.google.com/url?q=https://www.kurly.com">
+                                        <img src="https://github.com/user-attachments/assets/791b6dea-739c-49b0-b0a6-be490148ea46"
+                                             alt="딜리버리 로고" width="200" height="200" border="0"
+                                             style="display: block; margin: 0 auto;" class="CToWUd" data-bit="iit">
+                                    </a>
+                                </td>
+                            </tr>
+                            <!-- 본문 내용 -->
+                            <tr>
+                                <td style="background-color: #ffffff; border-radius: 16px; padding: 20px;
+                                                min-height: 200px; border: 1px solid #eeeeee; margin-bottom: 20px; width: 100%;">
+                                    <div style="width: 100%; min-height: 200px; font-family: Pretendard, sans-serif, Helvetica, Arial;
+                                                    white-space: pre-wrap; line-height: 0.7em; overflow: hidden;">
+                                        <p>안녕하세요, ${ name }님. ${ companyName } 채용담당자입니다.</p>
+                                        <p>${ companyName } ${ announcementTitle } 공고에 관심을 가지고 지원해주셔서 감사합니다.</p>
+                                        <p>이번 채용 전형에서는 ${ name }님을 모실 수 있게 되어 너무 영광입니다.</p>
+                                        <p>추후 채용 소식에 대해서 이메일과 알림으로 안내드리겠습니다.</p>
+                                        <p>감사합니다.</p>
+                                        <p>${ companyName } 드림</p>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+</body>
+
+</html>


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #487 
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
채용담당자가 서류결과를 일괄 전송할 수 있는 로직을 개선했습니다.
기존에 전송했던 인원에 대해서는 전송하지 않고, 새롭게 추가된 인원에 대해서만 전송하게 로직을 변경했습니다.
<br>

## ✅ 주요 작업 부분
- Alarm 엔티티 수정
- Resume 엔티티 수정
- AlarmRepository 로직 추가
- ResumeController 수정
- ResumeResultRes 정보 추가
- EmailSenderSeeker 중복 처리 로직 추가
- EmailService 로직 수정
- ResumeAcceptEmail 템플릿 추가

<br>