### PR TITLE
[#489][Refactor] 채용담당자 서류결과 일괄전송 로직 개선

### DIFF
--- a/frontend/src/pages/recruiter/resume/ResumeListPage.vue
+++ b/frontend/src/pages/recruiter/resume/ResumeListPage.vue
@@ -52,12 +52,10 @@ import MainHeaderComponent from "@/components/recruiter/MainHeaderComponent.vue"
 import { onMounted, ref, computed } from 'vue';
 import { UseResumeStore } from '@/stores/UseResumeStore';
 import { useRoute, useRouter } from 'vue-router';
-import { useToast } from "vue-toastification";
 
 const resumeStore = UseResumeStore();
 const route = useRoute();
 const router = useRouter();
-const toast = useToast();
 
 const currentPage = ref(1);
 const pageSize = 10;
@@ -98,11 +96,7 @@ const checkApplicationResult = (resumeResult) => {
 
 const sendResult = async () => {
     if (confirm("서류결과를 일괄 전송하시겠습니까?")) {
-        if (await resumeStore.sendResult(resumeStore.resumeList)) {
-            window.location.reload();
-        } else {
-          toast.error("일괄 처리 과정에서 오류가 발생했습니다. 관리자에게 문의하십시오.")
-        }
+        await resumeStore.sendResult(router, resumeStore.resumeList);
     }
 }
 </script>

--- a/frontend/src/stores/UseResumeStore.js
+++ b/frontend/src/stores/UseResumeStore.js
@@ -556,7 +556,7 @@ export const UseResumeStore = defineStore('resume', {
             }
         },
 
-        async sendResult(resumeList) {
+        async sendResult(router, resumeList) {
             const toast = useToast();
             try {
                 const response = await axios.post(`${backend}/resume/recruiter/send-result`,
@@ -566,9 +566,13 @@ export const UseResumeStore = defineStore('resume', {
                         withCredentials: true
                     });
 
-                console.log("resume result send email response : ", response);
-
-                return response.data.result;
+                if (response.data.success) {
+                    toast.success("일괄 전송에 성공했습니다.")
+                    router.push(`/recruiter/resume/list/${this.announcementIdx}`);
+                } else {
+                    toast.error("일괄 처리 과정에서 오류가 발생했습니다. 관리자에게 문의하십시오.")
+                }
+                return response.data.success;
 
             } catch (error) {
                 toast.error(error.response.data.message);


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #489
<br>


## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
채용담당자가 서류결과를 일괄 전송할 수 있는 로직을 개선했습니다.
기존에 로직을 전송하고 location.reload하는 부분, store에서 처리하게 수정했습니다.
<br>

## ✅ 주요 작업 부분
- ResumeListPage toast처리 삭제
- UseResumeStore toast처리 추가

<br>