### PR TITLE
[#533][Refactor] 공고 채용 프로세스 날짜 추가

### DIFF
--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/model/entity/Announcement.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/model/entity/Announcement.java
@@ -86,6 +86,10 @@ public class Announcement { //공고
     @Column(columnDefinition = "TEXT")
     private String process; // 전형절차
 
+    private String deadlineDocument; // 서류전형 마감날짜
+
+    private String deadlineFinal; // 전체전형 마감날짜
+
 
     // 유의사항
     @Column(columnDefinition = "TEXT")

--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/model/request/AnnouncementCreateReq.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/model/request/AnnouncementCreateReq.java
@@ -36,6 +36,8 @@ public class AnnouncementCreateReq {
     private String announcementEnd; // 모집마감
     private Integer interviewNum; // 면접횟수
     private String process; // 전형절차
+    private String deadlineDocument; // 서류전형 마감날짜
+    private String deadlineFinal; // 전체전형 마감날짜
 
     private String note; // 유의사항
 

--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/model/response/AnnouncementReadDetailRes.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/model/response/AnnouncementReadDetailRes.java
@@ -47,6 +47,8 @@ public class AnnouncementReadDetailRes {
     private String announcementEnd; // 모집마감
     private Integer interviewNum; // 면접횟수
     private String process; // 전형절차
+    private String deadlineDocument; // 서류전형 마감날짜
+    private String deadlineFinal; // 전체전형 마감날짜
 
     // 유의사항
     private String note; // 유의사항

--- a/backend/src/main/java/com/sabujaks/irs/domain/announcement/service/AnnouncementService.java
+++ b/backend/src/main/java/com/sabujaks/irs/domain/announcement/service/AnnouncementService.java
@@ -82,6 +82,8 @@ public class AnnouncementService {
                         .announcementStart(dto.getAnnouncementStart()) // 시작날
                         .announcementEnd(dto.getAnnouncementEnd()) // 종료날
                         .interviewNum(dto.getInterviewNum()) // 면접횟수
+                        .deadlineDocument(dto.getDeadlineDocument()) // 서류전형 마감날
+                        .deadlineFinal(dto.getDeadlineFinal()) // 전체전형 마감날
                         .imgUrl(fileUrl)
                         .build();
                 announcementRepository.save(announcement);
@@ -114,6 +116,8 @@ public class AnnouncementService {
                         .announcementStart(dto.getAnnouncementStart())
                         .announcementEnd(dto.getAnnouncementEnd())
                         .interviewNum(dto.getInterviewNum())
+                        .deadlineDocument(dto.getDeadlineDocument())
+                        .deadlineFinal(dto.getDeadlineFinal())
                         .note(dto.getNote())
                         .build();
                 announcementRepository.save(announcement);
@@ -280,6 +284,8 @@ public class AnnouncementService {
                         .announcementEnd(announcement.getAnnouncementEnd())
                         .interviewNum(announcement.getInterviewNum())
                         .process(announcement.getProcess())
+                        .deadlineDocument(announcement.getDeadlineDocument())
+                        .deadlineFinal(announcement.getDeadlineFinal())
                         .note(announcement.getNote())
 
                         .companyIndustry(company.getIndustry())


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #533
<br>

## 📌 구현 목표
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- Resolves: #(Isuue Number) -->
<!-- 게시글, 댓글, 대댓글 좋아요 기능 개발 및 좋아요 상태 확인 -->
채용 프로세스 날짜 추가
<br>

## ✅ 주요 작업 부분
공고에 서류전형, 전체전형 마감날짜 추가
announcement 엔티티
AnnouncementCreateReq 공고 등록시에 
AnnouncementReadDetailRes 공고 상세보기에 추가(채용담당자가 본인공고 상세조회시에만 나타나게 할 것임)
AnnouncementService 공고 등록과 공고상세조회 부분. readDetailSee, createAnnouncement
<br>