### PR TITLE
[#600][Refactor] 지원 프로세스, 면접 평가 로직 수정

### DIFF
--- a/backend/api/src/main/java/com/example/api/domain/system/DataInit.java
+++ b/backend/api/src/main/java/com/example/api/domain/system/DataInit.java
@@ -1,9 +1,9 @@
-//package com.sabujaks.irs.domain.system;
+//package com.example.api.domain.system;
 //
-//import com.sabujaks.irs.domain.system.model.entity.BaseInfo;
-//import com.sabujaks.irs.domain.system.repository.BaseInfoRepository;
-//import com.sabujaks.irs.domain.interview_schedule.model.entity.Team;
-//import com.sabujaks.irs.domain.interview_schedule.repository.TeamRepository;
+//import com.example.common.domain.interview_schedule.model.entity.Team;
+//import com.example.common.domain.interview_schedule.repository.TeamRepository;
+//import com.example.common.domain.system.model.entity.BaseInfo;
+//import com.example.common.domain.system.repository.BaseInfoRepository;
 //import jakarta.annotation.PostConstruct;
 //import lombok.RequiredArgsConstructor;
 //import org.springframework.stereotype.Component;

--- a/backend/api/src/main/java/com/example/api/domain/total_process/service/TotalProcessService.java
+++ b/backend/api/src/main/java/com/example/api/domain/total_process/service/TotalProcessService.java
@@ -36,6 +36,7 @@ public class TotalProcessService {
     private final TotalProcessRepository totalProcessRepository;
     private final RecruiterRepository recruiterRepository;
 
+    @Transactional
     public TotalProcessCreateRes create(TotalProcessCreateReq dto, CustomUserDetails customUserDetails) throws BaseException {
         Announcement announcement = announcementRepository.findByAnnounceIdx(dto.getAnnouncementIdx())
         .orElseThrow(() -> new BaseException(BaseResponseMessage.ANNOUNCEMENT_SEARCH_FAIL_NOT_FOUND));
@@ -49,42 +50,84 @@ public class TotalProcessService {
         if(result.isPresent()){
             TotalProcess totalProcess = result.get();
             if(dto.getInterviewNum() == 0) {
-                totalProcess.setResumeResult(isPassFlag);
+                if(!isPassFlag){ // 불합격하면
+                    totalProcess.setResumeResult(isPassFlag);
+                    totalProcess.setInterviewOneResult(isPassFlag);
+                    totalProcess.setInterviewTwoResult(isPassFlag);
+                    totalProcess.setFinalResult(isPassFlag);
+                } else { // 합격하면
+
+                    // 만약 채용담당자가 1차 2차 결과가 정해졌고, 지원서 결과만 수정하려고 할때와 진행상황이 지원서 부분일때
+                    if(result.get().getInterviewOneResult() != null && result.get().getInterviewTwoResult() != null && result.get().getFinalResult() != null){
+                        totalProcess.setResumeResult(isPassFlag);
+                    } else {
+                        totalProcess.setResumeResult(isPassFlag);
+                        totalProcess.setInterviewOneResult(null);
+                        totalProcess.setInterviewTwoResult(null);
+                        totalProcess.setFinalResult(null);
+                    }
+                }
             } else if(dto.getInterviewNum() == 1) {
-                totalProcess.setInterviewOneResult(isPassFlag);
-            }  else if (dto.getInterviewNum() == 2) {
-                totalProcess.setInterviewTwoResult(isPassFlag);
-            } else if (dto.getInterviewNum() == 3) {
-                totalProcess.setInterviewTwoResult(isPassFlag);
+                if(!isPassFlag){
+                    totalProcess.setInterviewOneResult(isPassFlag);
+                    totalProcess.setInterviewTwoResult(isPassFlag);
+                    totalProcess.setFinalResult(isPassFlag);
+                } else { // 합격하면
+                    // 만약 채용담당자가 2차 결과가 정해졌고, 1차 면접 결과만 수정하려고 할때와 진행상황이 지원서 부분일때
+                    if(result.get().getInterviewTwoResult() != null && result.get().getFinalResult() != null){
+                        totalProcess.setInterviewOneResult(isPassFlag);
+                    } else {
+                        totalProcess.setInterviewOneResult(isPassFlag);
+                        totalProcess.setInterviewTwoResult(null);
+                        totalProcess.setFinalResult(null);
+                    }
+                }
+            }  else if (dto.getInterviewNum() == 2) { // 2차 합격시 최종합격 불합
+                if(!isPassFlag){
+                    totalProcess.setInterviewTwoResult(isPassFlag);
+                    totalProcess.setFinalResult(isPassFlag);
+                } else {
+                    totalProcess.setInterviewTwoResult(isPassFlag);
+                    totalProcess.setFinalResult(isPassFlag);
+                }
             }
             totalProcess.setAnnouncement(announcement);
             totalProcess.setSeeker(seeker);
+            totalProcessRepository.save(totalProcess);
             return TotalProcessCreateRes.builder()
                     .idx(totalProcess.getIdx())
                     .build();
         }else {
+            // 전체 지원 과정이 없을때, 대부분 지원서 단계에서 걸림 -> 지원서 결과가 없다면 1차, 2차, 최종 결과는 DB 임의 조작의 경우만 있음
             TotalProcess totalProcess = null;
+            // 서류에 불합격
             if(dto.getInterviewNum() == 0) {
                 totalProcess = TotalProcess.builder()
                         .resumeResult(isPassFlag)
+                        .interviewOneResult(isPassFlag)
+                        .interviewTwoResult(isPassFlag)
+                        .finalResult(isPassFlag)
                         .announcement(announcement)
                         .seeker(seeker)
                         .build();
             } else if(dto.getInterviewNum() == 1) {
                 totalProcess = TotalProcess.builder()
                         .interviewOneResult(isPassFlag)
+                        .interviewTwoResult(isPassFlag)
+                        .finalResult(isPassFlag)
                         .announcement(announcement)
                         .seeker(seeker)
                         .build();
             }  else if (dto.getInterviewNum() == 2) {
                 totalProcess = TotalProcess.builder()
                         .interviewTwoResult(isPassFlag)
+                        .finalResult(isPassFlag)
                         .announcement(announcement)
                         .seeker(seeker)
                         .build();
             } else if (dto.getInterviewNum() == 3) {
                 totalProcess = TotalProcess.builder()
-                        .interviewOneResult(isPassFlag)
+                        .finalResult(isPassFlag)
                         .announcement(announcement)
                         .seeker(seeker)
                         .build();

--- a/cicd/docker-compose.yml
+++ b/cicd/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - ../cicd/mariadb:/var/lib/mysql
 
   openvidu:
-    image: openvidu/openvidu-dev:2.23.0
+    image: openvidu/openvidu-dev:2.30.0
     ports:
       - 4443:4443
     environment:


### PR DESCRIPTION
## 💭 연관된 이슈
<!-- #1 -->
closed #600
<br>

## 📌 구현 목표
채용담당자가 면접 1차 및 2차 평가에 대해 저장 안되는 문제 해결
<br>

## ✅ 주요 작업 부분
 엔티티 저장 추가
 불합격시 연쇄 불합격처리 ex) 지원서 불합격시 1차, 2차, 최종(interviewNum=3) 불합격 처리
 1차, 2차, 최종이 정해졌고, 내부적인 오류로 인한 수정 사항 발생시 1차를 수정하면 2차, 최종이 초기화됨
<br>